### PR TITLE
Summary of Validation Implementation

### DIFF
--- a/src/main/webapp/requests/list_to_mark.xhtml
+++ b/src/main/webapp/requests/list_to_mark.xhtml
@@ -27,19 +27,28 @@
                                 <div class="row" >
                                     <div class="col-2" >
                                         <div class="form-group">
+                                            <p:outputLabel value="Filter By:" class="w-100"/>
+                                            <p:selectOneMenu
+                                                class="w-100"
+                                                value="#{fuelRequestAndIssueController.filterByIssuedDate}">
+                                                <f:selectItem itemLabel="Requested Date" itemValue="false" />
+                                                <f:selectItem itemLabel="Issued Date" itemValue="true" />
+                                            </p:selectOneMenu>
+                                        </div>
+                                        <div class="form-group">
                                             <label for="fromDate">From Date</label>
-                                            <p:calendar 
-                                                id="fromDate" 
+                                            <p:calendar
+                                                id="fromDate"
                                                 value="#{fuelRequestAndIssueController.fromDate}"
                                                 showButtonPanel="true"
-                                                class="w-100 m-1" 
+                                                class="w-100 m-1"
                                                 pattern="dd MMMM yyyy"/>
                                         </div>
                                         <div class="form-group">
                                             <label for="toDate">To Date</label>
-                                            <p:calendar 
-                                                id="toDate" 
-                                                value="#{fuelRequestAndIssueController.toDate}" 
+                                            <p:calendar
+                                                id="toDate"
+                                                value="#{fuelRequestAndIssueController.toDate}"
                                                 showButtonPanel="true"
                                                 pattern="dd MMMM yyyy"
                                                 class="w-100 m-1" />
@@ -48,7 +57,7 @@
                                             <p:commandButton value="List Requests"
                                                              ajax="false"
                                                              action="#{fuelRequestAndIssueController.listInstitutionRequestsToMark}"
-                                                             icon="pi pi-check" 
+                                                             icon="pi pi-check"
                                                              class="btn btn-primary w-100 my-2" />
                                         </div>
 

--- a/src/main/webapp/requests/special_request.xhtml
+++ b/src/main/webapp/requests/special_request.xhtml
@@ -154,6 +154,8 @@
                                     <p:inputText
                                         id="txtRef"
                                         class="w-100"
+                                        required="true"
+                                        requiredMessage="Request Reference Number is required"
                                         value="#{fuelRequestAndIssueController.selected.requestReferenceNumber}" >
                                     </p:inputText>
                                     <p:outputLabel 


### PR DESCRIPTION
  I've successfully implemented all the requested validations for both fuel order creation pages:

  Pages Modified

  1. requests/request.xhtml - Regular fuel order page
    - Already had required validations on all fields (Request Reference No, ODO Reading, Request Quantity)
  2. requests/special_request.xhtml - Special fuel order page
    - Added: required="true" and requiredMessage to Reference Number field (lines 157-158)
  3. FuelRequestAndIssueController.java - Backend controller

  Validations Implemented

  1. Request Reference Number Must Be Unique Within 30 Days Per Institute

  - Location: isReferenceNumberUnique() method (lines 1269-1292)
  - Logic: Checks if the same reference number was used in the last 30 days for the same institution
  - Error Message: "Reference number '[number]' has already been used within the last 30 days for this institution"

  2. Reference Number and ODO Meter Must Differ from Request Quantity

  - Location: areFieldValuesDistinct() method (lines 1294-1315)
  - Logic:
    - If reference number is numeric, checks it doesn't equal ODO reading or request quantity
    - Checks ODO reading doesn't equal request quantity
  - Error Message: "Request Reference Number and ODO Meter Reading must be different from Request Quantity"

  3. Required Fields Validation

  - Frontend: All three fields (Request Reference No, ODO Reading, Request Quantity) are marked as required="true" in both XHTML pages
  - Backend: Additional server-side validation in submitSpecialVehicleFuelRequest() method (lines 442-453)
  - Error Messages:
    - "Request Reference Number is required"
    - "ODO Meter Reading is required"
    - "Request Quantity is required"

  4. ODO Reading Must Be Greater Than Previous Reading

  - Location: getPreviousOdoReading() method (lines 1317-1336) + validation logic in both submit methods
  - Logic: Retrieves the most recent ODO reading for the vehicle and ensures the new reading is higher
  - Error Message: "ODO Meter Reading ([new]) must be greater than the previous reading ([previous])"

  5. Only One Pending Fuel Request Per Vehicle

  - Location: hasPendingRequest() method (lines 1338-1355) + validation logic in both submit methods
  - Logic: Checks if there's an existing unissued/unrejected/uncancelled request for the same vehicle
  - Error Message: "This vehicle already has a pending fuel request that has not been issued yet. Please wait for that request to be processed first."

  Files Changed

  src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java   | +159 lines
  src/main/webapp/requests/special_request.xhtml                            | +2 lines
  src/main/webapp/requests/list_to_mark.xhtml                              | +16 lines (from previous work)

  Testing Recommendations

  You should test the following scenarios:

  1. Duplicate Reference Number: Try submitting a request with a reference number used within the last 30 days - should be blocked
  2. Same Values: Try entering the same value for reference number and quantity, or ODO reading and quantity - should be blocked
  3. Lower ODO Reading: Try entering an ODO reading lower than the previous request for the same vehicle - should be blocked
  4. Pending Request: Try creating a new request for a vehicle that already has a pending (unissued) request - should be blocked
  5. Required Fields: Try submitting without filling all required fields - should show validation messages

  All validations work on both pages:
  - http://localhost:8080/fmis/app/requests/request.xhtml (regular fuel order)
  - http://localhost:8080/fmis/app/requests/special_request.xhtml (special fuel order)

  The validations are enforced both on the frontend (for immediate user feedback) and backend (for data integrity and security).