### PR TITLE
Changes Made:

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
@@ -1152,6 +1152,8 @@ public class FuelRequestAndIssueController implements Serializable {
     }
 
     public void listInstitutionRequestsToPay() {
+        // Always filter by issued date for payment requests
+        filterByIssuedDate = true;
         transactions
                 = findFuelTransactions(
                         null, // institution

--- a/src/main/webapp/requests/list_to_pay.xhtml
+++ b/src/main/webapp/requests/list_to_pay.xhtml
@@ -27,15 +27,6 @@
                                 <div class="row" >
                                     <div class="col-3 p-2" >
                                         <h:panelGrid columns="2" >
-                                            <label for="dateFilterType">Date Filter Type</label>
-                                            <p:selectOneMenu
-                                                id="dateFilterType"
-                                                class="w-100 m-1"
-                                                value="#{fuelRequestAndIssueController.filterByIssuedDate}">
-                                                <f:selectItem itemLabel="Requested Date" itemValue="false" />
-                                                <f:selectItem itemLabel="Issued Date" itemValue="true" />
-                                            </p:selectOneMenu>
-
                                             <label for="fromDate">From Date</label>
                                             <p:calendar
                                                 id="fromDate"


### PR DESCRIPTION
Closes #106 

  1. list_to_pay.xhtml (D:\Dev\fmis\src\main\webapp\requests\list_to_pay.xhtml:30-37)

  - Removed the "Date Filter Type" dropdown that allowed users to choose between "Requested Date" and "Issued Date"
  - The page now only shows the "From Date" and "To Date" fields

  2. FuelRequestAndIssueController.java (D:\Dev\fmis\src\main\java\lk\gov\health\phsp\bean\FuelRequestAndIssueController.java:1156)

  - Updated the listInstitutionRequestsToPay() method to always set filterByIssuedDate = true before fetching transactions
  - This ensures that the date range filter will always use the fuel transactions' issuedDate field instead of the requestedDate

  The page will now consistently filter payment requests based on the issued date of fuel transactions, which makes
  more sense for payment processing as you want to pay for fuel that has actually been issued, not just requested.