### PR TITLE
Restrict mobile dispense to the order's fuel shed (#122)

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/RestQrScanController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/RestQrScanController.java
@@ -2,6 +2,7 @@ package lk.gov.health.phsp.bean;
 
 import lk.gov.health.phsp.entity.FuelTransaction;
 import lk.gov.health.phsp.entity.FuelTransactionImage;
+import lk.gov.health.phsp.entity.Institution;
 import lk.gov.health.phsp.entity.Vehicle;
 import lk.gov.health.phsp.entity.WebUser;
 import lk.gov.health.phsp.facade.FuelTransactionFacade;
@@ -116,7 +117,7 @@ public class RestQrScanController {
 
                             if (vehicle != null && !vehicle.isRetired()) {
                                 System.out.println("Vehicle found using JSON ID - ID: " + vehicle.getId() + ", Number: " + vehicle.getVehicleNumber());
-                                response = buildVehicleResponseWithTransactions(vehicle);
+                                response = buildVehicleResponseWithTransactions(vehicle, currentUser);
                                 response.put("success", true);
                                 response.put("type", "vehicle");
                                 return Response.ok(response).build();
@@ -140,7 +141,7 @@ public class RestQrScanController {
 
                         if (vehicle != null) {
                             System.out.println("Vehicle found using JSON vehicle number - ID: " + vehicle.getId() + ", Number: " + vehicle.getVehicleNumber());
-                            response = buildVehicleResponseWithTransactions(vehicle);
+                            response = buildVehicleResponseWithTransactions(vehicle, currentUser);
                             response.put("success", true);
                             response.put("type", "vehicle");
                             return Response.ok(response).build();
@@ -186,7 +187,7 @@ public class RestQrScanController {
 
             if (vehicle != null) {
                 System.out.println("Vehicle found by registration number - ID: " + vehicle.getId() + ", Number: " + vehicle.getVehicleNumber());
-                response = buildVehicleResponseWithTransactions(vehicle);
+                response = buildVehicleResponseWithTransactions(vehicle, currentUser);
                 response.put("success", true);
                 response.put("type", "vehicle");
                 return Response.ok(response).build();
@@ -204,7 +205,7 @@ public class RestQrScanController {
                     System.out.println("Vehicle found - ID: " + vehicle.getId() + ", Retired: " + vehicle.isRetired());
                     if (!vehicle.isRetired()) {
                         System.out.println("Vehicle matched successfully");
-                        response = buildVehicleResponseWithTransactions(vehicle);
+                        response = buildVehicleResponseWithTransactions(vehicle, currentUser);
                         response.put("success", true);
                         response.put("type", "vehicle");
                         return Response.ok(response).build();
@@ -302,6 +303,12 @@ public class RestQrScanController {
                 response.put("success", false);
                 response.put("message", "Transaction already dispensed");
                 return Response.status(Response.Status.BAD_REQUEST).entity(response).build();
+            }
+
+            // Enforce: dispenser must belong to the fuel shed the order was directed to
+            Response institutionError = checkDispenseInstitution(transaction, currentUser);
+            if (institutionError != null) {
+                return institutionError;
             }
 
             // Note: Dispensing happens BEFORE issuing in this workflow
@@ -476,6 +483,12 @@ public class RestQrScanController {
                 response.put("success", false);
                 response.put("message", "Transaction already dispensed");
                 return Response.status(Response.Status.BAD_REQUEST).entity(response).build();
+            }
+
+            // Enforce: dispenser must belong to the fuel shed the order was directed to
+            Response institutionError = checkDispenseInstitution(transaction, currentUser);
+            if (institutionError != null) {
+                return institutionError;
             }
 
             // Read image bytes
@@ -677,6 +690,40 @@ public class RestQrScanController {
         return null;
     }
 
+    /**
+     * Verify that the dispenser's institution matches the fuel shed (toInstitution)
+     * the transaction was ordered from. Strict match — no parent/child fallback.
+     *
+     * @return null if authorized, otherwise a 403 Response with an explanatory message.
+     */
+    private Response checkDispenseInstitution(FuelTransaction transaction, WebUser currentUser) {
+        Map<String, Object> body = new HashMap<>();
+        Institution userInstitution = currentUser.getInstitution();
+        Institution toInstitution = transaction.getToInstitution();
+
+        if (userInstitution == null || userInstitution.getId() == null) {
+            body.put("success", false);
+            body.put("message", "Your account has no institution assigned. Cannot dispense fuel.");
+            return Response.status(Response.Status.FORBIDDEN).entity(body).build();
+        }
+
+        if (toInstitution == null || toInstitution.getId() == null) {
+            body.put("success", false);
+            body.put("message", "This transaction has no fuel shed assigned and cannot be dispensed via the mobile app.");
+            return Response.status(Response.Status.FORBIDDEN).entity(body).build();
+        }
+
+        if (!userInstitution.getId().equals(toInstitution.getId())) {
+            body.put("success", false);
+            body.put("message", "This fuel was ordered from " + toInstitution.getName()
+                    + ". You can only dispense fuel ordered from your institution: "
+                    + userInstitution.getName());
+            return Response.status(Response.Status.FORBIDDEN).entity(body).build();
+        }
+
+        return null;
+    }
+
     private WebUser authenticateUser(String authHeader) {
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
             return null;
@@ -760,20 +807,33 @@ public class RestQrScanController {
         return data;
     }
 
-    private Map<String, Object> buildVehicleResponseWithTransactions(Vehicle vehicle) {
+    private Map<String, Object> buildVehicleResponseWithTransactions(Vehicle vehicle, WebUser currentUser) {
         Map<String, Object> data = buildVehicleResponse(vehicle);
 
-        // Find pending transactions for this vehicle (not yet dispensed)
-        System.out.println("Looking up pending transactions for vehicle ID: " + vehicle.getId());
+        // Only show transactions ordered from THIS dispenser's fuel shed.
+        // Strict match against the user's institution; no parent/child fallback,
+        // mirroring FuelDispenseController.searchFuelTransactionByVehicleQr.
+        Institution userInstitution = currentUser != null ? currentUser.getInstitution() : null;
+        if (userInstitution == null || userInstitution.getId() == null) {
+            System.out.println("User has no institution; returning empty pendingTransactions");
+            data.put("pendingTransactions", new java.util.ArrayList<>());
+            return data;
+        }
+
+        // Find pending transactions for this vehicle ordered from the user's fuel shed
+        System.out.println("Looking up pending transactions for vehicle ID: " + vehicle.getId()
+                + " at fuel shed (institution): " + userInstitution.getId());
         String jpql = "SELECT t FROM FuelTransaction t WHERE t.vehicle.id = :vehicleId "
                 + "AND t.retired = false "
                 + "AND t.dispensed = false "
                 + "AND t.cancelled = false "
                 + "AND t.rejected = false "
+                + "AND t.toInstitution.id = :institutionId "
                 + "ORDER BY t.requestedDate DESC";
 
         Map<String, Object> params = new HashMap<>();
         params.put("vehicleId", vehicle.getId());
+        params.put("institutionId", userInstitution.getId());
 
         try {
             java.util.List<FuelTransaction> transactions = fuelTransactionFacade.findByJpql(jpql, params);


### PR DESCRIPTION
Closes #122.

## Summary
- Mobile QR/dispense API now requires the dispenser's institution to match `FuelTransaction.toInstitution` (the fuel shed the order was directed to).
- Strict equality only — no parent/child institution fallback. Mirrors the rule already enforced by `FuelDispenseController.searchFuelTransactionByVehicleQr`.
- A `null` `toInstitution` is treated as unauthorized (cannot silently bypass).

## Changes
**`src/main/java/lk/gov/health/phsp/bean/RestQrScanController.java`**

1. `buildVehicleResponseWithTransactions(...)` now takes the current user and adds `AND t.toInstitution.id = :institutionId` to the pending-transaction JPQL. Mobile no longer sees orders directed to other fuel sheds.
2. New helper `checkDispenseInstitution(transaction, currentUser)` returns a **403 Forbidden** with a descriptive message if:
   - the user has no institution, or
   - the transaction has no `toInstitution`, or
   - the two don't match.
3. Both `/api/qr/dispense` and `/api/qr/dispense-with-image` invoke the check after state validations and before any mutation.

## Test plan
- [ ] As a dispenser at Shed A, scan a vehicle whose pending order is directed to Shed B → vehicle response returns no pending transaction for that order.
- [ ] As Shed A, call `/api/qr/dispense-with-image` with a transaction whose `toInstitution` is Shed B → 403 with message naming both shed names; transaction unchanged in DB.
- [ ] As Shed A, dispensing an order directed to Shed A still works end-to-end.
- [ ] A transaction with `toInstitution = null` cannot be dispensed via mobile (403).

> Note: requires backend WAR rebuild and redeploy to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)