### PR TITLE
Use DTO-backed autocompletes for vehicle and driver on special_request

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/DriverController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/DriverController.java
@@ -8,7 +8,9 @@ import lk.gov.health.phsp.facade.DriverFacade;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -21,10 +23,12 @@ import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.faces.convert.FacesConverter;
 import javax.inject.Inject;
+import javax.persistence.TemporalType;
 import lk.gov.health.phsp.entity.Institution;
 import lk.gov.health.phsp.enums.InstitutionCategory;
 import lk.gov.health.phsp.enums.WebUserRoleLevel;
 import lk.gov.health.phsp.facade.AreaFacade;
+import lk.gov.health.phsp.pojcs.DriverLightDTO;
 
 @Named
 @SessionScoped
@@ -51,6 +55,8 @@ public class DriverController implements Serializable {
     private List<Driver> items = null;
     private Driver selected;
     private Driver deleting;
+
+    private List<DriverLightDTO> lastDriverLightDtoResults;
 
     private Driver parent;
 
@@ -229,6 +235,44 @@ public class DriverController implements Serializable {
             }
         }
         return resIns;
+    }
+
+    /**
+     * DTO-based autocomplete that searches every non-retired driver by name,
+     * NIC, or phone. Used where the picker must span all institutions
+     * (e.g. special fuel requests). Each typed word must match at least one
+     * of the three columns; capped at 20 rows.
+     */
+    public List<DriverLightDTO> completeAllDriversByWordsDto(String nameQry) {
+        if (nameQry == null || nameQry.trim().isEmpty()) {
+            lastDriverLightDtoResults = new ArrayList<>();
+            return lastDriverLightDtoResults;
+        }
+
+        String[] words = nameQry.trim().split("\\s+");
+        StringBuilder jpql = new StringBuilder(
+                "SELECT NEW lk.gov.health.phsp.pojcs.DriverLightDTO("
+                + "d.id, d.name, d.nic, d.phone, d.allocationType, ins.id, ins.name) "
+                + "FROM Driver d LEFT JOIN d.institution ins "
+                + "WHERE d.retired = false ");
+
+        Map<String, Object> params = new HashMap<>();
+        for (int i = 0; i < words.length; i++) {
+            String paramName = "q" + i;
+            jpql.append("AND (LOWER(d.name) LIKE :").append(paramName)
+                    .append(" OR LOWER(d.nic) LIKE :").append(paramName)
+                    .append(" OR LOWER(d.phone) LIKE :").append(paramName)
+                    .append(") ");
+            params.put(paramName, "%" + words[i].toLowerCase() + "%");
+        }
+        jpql.append("ORDER BY d.name");
+
+        @SuppressWarnings("unchecked")
+        List<DriverLightDTO> results = (List<DriverLightDTO>) getFacade()
+                .findLightsByJpql(jpql.toString(), params, TemporalType.TIMESTAMP, 20);
+
+        lastDriverLightDtoResults = results != null ? results : new ArrayList<DriverLightDTO>();
+        return lastDriverLightDtoResults;
     }
 
     public Driver prepareCreate() {
@@ -469,6 +513,45 @@ public class DriverController implements Serializable {
 
     public void setStartMessage(String startMessage) {
         this.startMessage = startMessage;
+    }
+
+    @FacesConverter("driverLightDtoConverter")
+    public static class DriverLightDtoConverter implements Converter {
+
+        @Override
+        public Object getAsObject(FacesContext facesContext, UIComponent component, String value) {
+            if (value == null || value.length() == 0) {
+                return null;
+            }
+            Long id;
+            try {
+                id = Long.valueOf(value);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+            DriverController controller = (DriverController) facesContext.getApplication().getELResolver()
+                    .getValue(facesContext.getELContext(), null, "driverController");
+            if (controller != null && controller.lastDriverLightDtoResults != null) {
+                for (DriverLightDTO dto : controller.lastDriverLightDtoResults) {
+                    if (id.equals(dto.getId())) {
+                        return dto;
+                    }
+                }
+            }
+            return new DriverLightDTO(id);
+        }
+
+        @Override
+        public String getAsString(FacesContext facesContext, UIComponent component, Object object) {
+            if (object == null) {
+                return "";
+            }
+            if (object instanceof DriverLightDTO) {
+                Long id = ((DriverLightDTO) object).getId();
+                return id != null ? id.toString() : "";
+            }
+            return "";
+        }
     }
 
     @FacesConverter(forClass = Driver.class)

--- a/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
@@ -27,6 +27,7 @@ import lk.gov.health.phsp.bean.util.JsfUtil;
 import lk.gov.health.phsp.entity.Bill;
 import lk.gov.health.phsp.entity.BillItem;
 import lk.gov.health.phsp.entity.DataAlterationRequest;
+import lk.gov.health.phsp.entity.Driver;
 import lk.gov.health.phsp.entity.FuelPrice;
 import lk.gov.health.phsp.entity.FuelTransactionHistory;
 import lk.gov.health.phsp.entity.Institution;
@@ -37,12 +38,15 @@ import lk.gov.health.phsp.enums.FuelTransactionType;
 import lk.gov.health.phsp.facade.BillFacade;
 import lk.gov.health.phsp.facade.BillItemFacade;
 import lk.gov.health.phsp.facade.DataAlterationRequestFacade;
+import lk.gov.health.phsp.facade.DriverFacade;
 import lk.gov.health.phsp.facade.FuelPriceFacade;
 import lk.gov.health.phsp.facade.FuelTransactionFacade;
 import lk.gov.health.phsp.facade.InstitutionFacade;
 import lk.gov.health.phsp.facade.VehicleFacade;
 import lk.gov.health.phsp.facade.WebUserFacade;
 import lk.gov.health.phsp.pojcs.BillItemMigrationResults;
+import lk.gov.health.phsp.pojcs.DriverLightDTO;
+import lk.gov.health.phsp.pojcs.VehicleLightDTO;
 import org.primefaces.event.CaptureEvent;
 
 @Named
@@ -59,6 +63,8 @@ public class FuelRequestAndIssueController implements Serializable {
     InstitutionFacade institutionFacade;
     @EJB
     VehicleFacade vehicleFacade;
+    @EJB
+    DriverFacade driverFacade;
     @EJB
     WebUserFacade webUserFacade;
     @EJB
@@ -117,6 +123,9 @@ public class FuelRequestAndIssueController implements Serializable {
     private Map<Long, String> billItemComments; // Map of transaction ID to comment
 
     private String searchingFuelRequestVehicleNumber;
+
+    private VehicleLightDTO vehicleDto;
+    private DriverLightDTO driverDto;
 
     // Certified Receipt Upload
     private org.primefaces.model.file.UploadedFile certifiedReceiptFile;
@@ -1004,6 +1013,8 @@ public class FuelRequestAndIssueController implements Serializable {
         selected.setFromInstitution(webUserController.getLoggedInstitution());
         selected.setInstitution(webUserController.getLoggedInstitution());
         selected.setToInstitution(webUserController.getLoggedInstitution().getSupplyInstitution());
+        vehicleDto = null;
+        driverDto = null;
         return "/requests/special_request?faces-redirect=true";
     }
 
@@ -2449,6 +2460,68 @@ public class FuelRequestAndIssueController implements Serializable {
 
     public void setSelected(FuelTransaction selected) {
         this.selected = selected;
+    }
+
+    public VehicleLightDTO getVehicleDto() {
+        if (vehicleDto == null && selected != null && selected.getVehicle() != null
+                && selected.getVehicle().getId() != null) {
+            Vehicle v = selected.getVehicle();
+            Institution ins = v.getInstitution();
+            vehicleDto = new VehicleLightDTO(
+                    v.getId(),
+                    v.getVehicleNumber(),
+                    v.getName(),
+                    v.getAllocationType(),
+                    ins != null ? ins.getId() : null,
+                    ins != null ? ins.getName() : null);
+        }
+        return vehicleDto;
+    }
+
+    public void setVehicleDto(VehicleLightDTO vehicleDto) {
+        this.vehicleDto = vehicleDto;
+        if (selected == null) {
+            return;
+        }
+        if (vehicleDto == null || vehicleDto.getId() == null) {
+            selected.setVehicle(null);
+            return;
+        }
+        Vehicle current = selected.getVehicle();
+        if (current == null || current.getId() == null
+                || !vehicleDto.getId().equals(current.getId())) {
+            selected.setVehicle(vehicleFacade.find(vehicleDto.getId()));
+        }
+    }
+
+    public DriverLightDTO getDriverDto() {
+        if (driverDto == null && selected != null && selected.getDriver() != null
+                && selected.getDriver().getId() != null) {
+            Driver d = selected.getDriver();
+            Institution ins = d.getInstitution();
+            driverDto = new DriverLightDTO(
+                    d.getId(), d.getName(), d.getNic(), d.getPhone(),
+                    d.getAllocationType(),
+                    ins != null ? ins.getId() : null,
+                    ins != null ? ins.getName() : null);
+        }
+        return driverDto;
+    }
+
+    public void setDriverDto(DriverLightDTO driverDto) {
+        this.driverDto = driverDto;
+        if (selected == null) {
+            return;
+        }
+        if (driverDto == null || driverDto.getId() == null) {
+            selected.setDriver(null);
+            return;
+        }
+        Driver current = selected.getDriver();
+        if (current == null || current.getId() == null
+                || !driverDto.getId().equals(current.getId())) {
+            selected.setDriver(driverFacade.find(driverDto.getId()));
+        }
     }
 
     public FuelTransaction find(Object id) {

--- a/src/main/java/lk/gov/health/phsp/bean/VehicleController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/VehicleController.java
@@ -22,11 +22,15 @@ import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.faces.convert.FacesConverter;
 import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.Map;
+import javax.persistence.TemporalType;
 import lk.gov.health.phsp.entity.Institution;
 import lk.gov.health.phsp.enums.VehicleType;
 import lk.gov.health.phsp.enums.WebUserRole;
 import lk.gov.health.phsp.enums.WebUserRoleLevel;
 import lk.gov.health.phsp.facade.AreaFacade;
+import lk.gov.health.phsp.pojcs.VehicleLightDTO;
 
 import com.google.zxing.*;
 import com.google.zxing.client.j2se.MatrixToImageWriter;
@@ -72,6 +76,8 @@ public class VehicleController implements Serializable {
     private List<Vehicle> items = null;
     private Vehicle selected;
     private Vehicle deleting;
+
+    private List<VehicleLightDTO> lastVehicleLightDtoResults;
 
     private VehicleType vehicleType;
     private Vehicle parent;
@@ -440,6 +446,42 @@ public class VehicleController implements Serializable {
         return resIns;
     }
 
+    /**
+     * DTO-based autocomplete returning every non-retired vehicle in the system.
+     * Used where the caller must be able to pick a vehicle owned by any
+     * institution (e.g. special fuel requests). Loads only the columns needed
+     * for display so the query stays fast even with thousands of vehicles.
+     */
+    public List<VehicleLightDTO> completeAllVehiclesByWordsDto(String nameQry) {
+        if (nameQry == null || nameQry.trim().isEmpty()) {
+            lastVehicleLightDtoResults = new ArrayList<>();
+            return lastVehicleLightDtoResults;
+        }
+
+        String[] words = nameQry.trim().split("\\s+");
+        StringBuilder jpql = new StringBuilder(
+                "SELECT NEW lk.gov.health.phsp.pojcs.VehicleLightDTO("
+                + "v.id, v.vehicleNumber, v.name, v.allocationType, ins.id, ins.name) "
+                + "FROM Vehicle v LEFT JOIN v.institution ins "
+                + "WHERE v.retired = false ");
+
+        Map<String, Object> params = new HashMap<>();
+        for (int i = 0; i < words.length; i++) {
+            String paramName = "q" + i;
+            jpql.append("AND (LOWER(v.vehicleNumber) LIKE :").append(paramName)
+                    .append(" OR LOWER(v.name) LIKE :").append(paramName).append(") ");
+            params.put(paramName, "%" + words[i].toLowerCase() + "%");
+        }
+        jpql.append("ORDER BY v.vehicleNumber");
+
+        @SuppressWarnings("unchecked")
+        List<VehicleLightDTO> results = (List<VehicleLightDTO>) getFacade()
+                .findLightsByJpql(jpql.toString(), params, TemporalType.TIMESTAMP, 20);
+
+        lastVehicleLightDtoResults = results != null ? results : new ArrayList<VehicleLightDTO>();
+        return lastVehicleLightDtoResults;
+    }
+
     public Vehicle prepareCreate() {
         selected = new Vehicle();
         initializeEmbeddableKey();
@@ -715,6 +757,45 @@ public class VehicleController implements Serializable {
 
     public void setStartMessage(String startMessage) {
         this.startMessage = startMessage;
+    }
+
+    @FacesConverter("vehicleLightDtoConverter")
+    public static class VehicleLightDtoConverter implements Converter {
+
+        @Override
+        public Object getAsObject(FacesContext facesContext, UIComponent component, String value) {
+            if (value == null || value.length() == 0) {
+                return null;
+            }
+            Long id;
+            try {
+                id = Long.valueOf(value);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+            VehicleController controller = (VehicleController) facesContext.getApplication().getELResolver()
+                    .getValue(facesContext.getELContext(), null, "vehicleController");
+            if (controller != null && controller.lastVehicleLightDtoResults != null) {
+                for (VehicleLightDTO dto : controller.lastVehicleLightDtoResults) {
+                    if (id.equals(dto.getId())) {
+                        return dto;
+                    }
+                }
+            }
+            return new VehicleLightDTO(id);
+        }
+
+        @Override
+        public String getAsString(FacesContext facesContext, UIComponent component, Object object) {
+            if (object == null) {
+                return "";
+            }
+            if (object instanceof VehicleLightDTO) {
+                Long id = ((VehicleLightDTO) object).getId();
+                return id != null ? id.toString() : "";
+            }
+            return "";
+        }
     }
 
     @FacesConverter(forClass = Vehicle.class)

--- a/src/main/java/lk/gov/health/phsp/pojcs/DriverLightDTO.java
+++ b/src/main/java/lk/gov/health/phsp/pojcs/DriverLightDTO.java
@@ -1,0 +1,111 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2026 Dr M H B Ariyaratne <buddhika.ari at gmail.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ */
+package lk.gov.health.phsp.pojcs;
+
+import java.io.Serializable;
+import lk.gov.health.phsp.enums.DriverAllocationType;
+
+/**
+ * Lightweight DTO used to populate the driver autocomplete without loading
+ * full Driver entities for every row.
+ */
+public class DriverLightDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private String name;
+    private String nic;
+    private String phone;
+    private DriverAllocationType allocationType;
+    private Long institutionId;
+    private String institutionName;
+
+    public DriverLightDTO() {
+    }
+
+    public DriverLightDTO(Long id) {
+        this.id = id;
+    }
+
+    public DriverLightDTO(Long id, String name, String nic, String phone,
+            DriverAllocationType allocationType,
+            Long institutionId, String institutionName) {
+        this.id = id;
+        this.name = name;
+        this.nic = nic;
+        this.phone = phone;
+        this.allocationType = allocationType;
+        this.institutionId = institutionId;
+        this.institutionName = institutionName;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getNic() {
+        return nic;
+    }
+
+    public void setNic(String nic) {
+        this.nic = nic;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public DriverAllocationType getAllocationType() {
+        return allocationType;
+    }
+
+    public void setAllocationType(DriverAllocationType allocationType) {
+        this.allocationType = allocationType;
+    }
+
+    public Long getInstitutionId() {
+        return institutionId;
+    }
+
+    public void setInstitutionId(Long institutionId) {
+        this.institutionId = institutionId;
+    }
+
+    public String getInstitutionName() {
+        return institutionName;
+    }
+
+    public void setInstitutionName(String institutionName) {
+        this.institutionName = institutionName;
+    }
+}

--- a/src/main/java/lk/gov/health/phsp/pojcs/VehicleLightDTO.java
+++ b/src/main/java/lk/gov/health/phsp/pojcs/VehicleLightDTO.java
@@ -1,0 +1,101 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2026 Dr M H B Ariyaratne <buddhika.ari at gmail.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ */
+package lk.gov.health.phsp.pojcs;
+
+import java.io.Serializable;
+import lk.gov.health.phsp.enums.VehicleAllocationType;
+
+/**
+ * Lightweight DTO used to populate the vehicle autocomplete without loading
+ * full Vehicle entities for thousands of rows.
+ */
+public class VehicleLightDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private String vehicleNumber;
+    private String name;
+    private VehicleAllocationType allocationType;
+    private Long institutionId;
+    private String institutionName;
+
+    public VehicleLightDTO() {
+    }
+
+    public VehicleLightDTO(Long id) {
+        this.id = id;
+    }
+
+    public VehicleLightDTO(Long id, String vehicleNumber, String name,
+            VehicleAllocationType allocationType,
+            Long institutionId, String institutionName) {
+        this.id = id;
+        this.vehicleNumber = vehicleNumber;
+        this.name = name;
+        this.allocationType = allocationType;
+        this.institutionId = institutionId;
+        this.institutionName = institutionName;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getVehicleNumber() {
+        return vehicleNumber;
+    }
+
+    public void setVehicleNumber(String vehicleNumber) {
+        this.vehicleNumber = vehicleNumber;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public VehicleAllocationType getAllocationType() {
+        return allocationType;
+    }
+
+    public void setAllocationType(VehicleAllocationType allocationType) {
+        this.allocationType = allocationType;
+    }
+
+    public Long getInstitutionId() {
+        return institutionId;
+    }
+
+    public void setInstitutionId(Long institutionId) {
+        this.institutionId = institutionId;
+    }
+
+    public String getInstitutionName() {
+        return institutionName;
+    }
+
+    public void setInstitutionName(String institutionName) {
+        this.institutionName = institutionName;
+    }
+}

--- a/src/main/webapp/requests/special_request.xhtml
+++ b/src/main/webapp/requests/special_request.xhtml
@@ -46,8 +46,9 @@
                                             <div class="col-12 col-sm-8 col-md-9">
                                                 <p:autoComplete
                                                     id="acVehicle"
-                                                    value="#{fuelRequestAndIssueController.selected.vehicle}"
-                                                    completeMethod="#{vehicleController.completeVehiclesByWords}"
+                                                    value="#{fuelRequestAndIssueController.vehicleDto}"
+                                                    completeMethod="#{vehicleController.completeAllVehiclesByWordsDto}"
+                                                    converter="vehicleLightDtoConverter"
                                                     var="v"
                                                     style="width: 100%"
                                                     inputStyleClass="w-100"
@@ -59,6 +60,12 @@
                                                     requiredMessage="Please select a Vehicle"
                                                     title="Please select a vehicle"
                                                     placeholder="Select a vehicle by typing few letters to search">
+                                                    <p:column headerText="Vehicle">
+                                                        <h:outputText value="#{v.vehicleNumber}" />
+                                                    </p:column>
+                                                    <p:column headerText="Institution">
+                                                        <h:outputText value="#{v.institutionName}" />
+                                                    </p:column>
                                                     <p:ajax process="acVehicle" update="insDropdown acDriver" ></p:ajax>
                                                 </p:autoComplete>
                                             </div>
@@ -95,19 +102,35 @@
                                                 <p:outputLabel for="acDriver" value="Driver" styleClass="font-weight-bold"/>
                                             </div>
                                             <div class="col-12 col-sm-8 col-md-9">
-                                                <p:selectOneMenu
+                                                <p:autoComplete
                                                     id="acDriver"
-                                                    value="#{fuelRequestAndIssueController.selected.driver}"
-                                                    filter="true"
-                                                    filterMatchMode="contains"
+                                                    value="#{fuelRequestAndIssueController.driverDto}"
+                                                    completeMethod="#{driverController.completeAllDriversByWordsDto}"
+                                                    converter="driverLightDtoConverter"
+                                                    var="d"
+                                                    style="width: 100%"
+                                                    inputStyleClass="w-100"
+                                                    forceSelection="true"
+                                                    maxResults="20"
+                                                    itemLabel="#{d.name}#{d.allocationType ne null ? ' ('.concat(d.allocationType.label).concat(')') : ''}"
+                                                    itemValue="#{d}"
                                                     required="true"
                                                     requiredMessage="You must select a driver"
-                                                    style="width: 100%"
-                                                    panelStyle="max-width: 90vw">
-                                                    <f:selectItem itemLabel="Select a driver"  />
-                                                    <f:selectItems value="#{driverController.institutionDrivers(fuelRequestAndIssueController.selected.fromInstitution)}" var="d"
-                                                                   itemLabel="#{d.name}#{d.allocationType ne null ? ' ('.concat(d.allocationType.label).concat(')') : ''}" itemValue="#{d}" />
-                                                </p:selectOneMenu>
+                                                    title="Search by name, NIC, or phone"
+                                                    placeholder="Search by name, NIC, or phone">
+                                                    <p:column headerText="Name">
+                                                        <h:outputText value="#{d.name}" />
+                                                    </p:column>
+                                                    <p:column headerText="NIC">
+                                                        <h:outputText value="#{d.nic}" />
+                                                    </p:column>
+                                                    <p:column headerText="Phone">
+                                                        <h:outputText value="#{d.phone}" />
+                                                    </p:column>
+                                                    <p:column headerText="Institution">
+                                                        <h:outputText value="#{d.institutionName}" />
+                                                    </p:column>
+                                                </p:autoComplete>
                                             </div>
                                         </div>
 


### PR DESCRIPTION
## Summary
- Adds `VehicleLightDTO` / `DriverLightDTO` and DTO-backed autocomplete methods to `VehicleController` / `DriverController`, capped at 20 rows and built via JPQL `SELECT NEW … LEFT JOIN institution`.
- Vehicle autocomplete on `requests/special_request.xhtml` now spans every non-retired vehicle (no institution filter); driver picker becomes a `p:autoComplete` searchable by **name, NIC, or phone**, replacing the old institution-scoped `selectOneMenu`.
- `FuelRequestAndIssueController.setVehicleDto` / `setDriverDto` resolve the picked id back to the full entity via the facades, so dependent controls (institution dropdown, validators, confirmation dialog, save-time persistence) keep working unchanged.

Closes #124.

## Test plan
- [ ] Open `/app/requests/special_request.xhtml` as a non-CPC, non-HEALTH_MINISTRY user and verify the vehicle autocomplete returns vehicles from other institutions.
- [ ] Type a partial vehicle number / vehicle name and confirm matches return within 20 rows.
- [ ] Pick a vehicle and confirm the institution dropdown still populates with the vehicle's permanent / temporarily-attached institutions.
- [ ] Type a driver name fragment, an NIC fragment, and a phone-number fragment — each should return matching drivers.
- [ ] Pick a driver and submit the request; verify the saved `FuelTransaction` has the correct `vehicle` and `driver` ids.
- [ ] Confirmation dialog still shows vehicle number, allocation type, driver name, and allocation type correctly.
- [ ] Re-open the page and start a fresh request — both autocomplete fields start empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)