### PR TITLE
Show dispense receipt image on all transaction detail views

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
@@ -1,7 +1,9 @@
 package lk.gov.health.phsp.bean;
 
 import lk.gov.health.phsp.entity.FuelTransaction;
+import lk.gov.health.phsp.entity.FuelTransactionImage;
 import lk.gov.health.phsp.facade.FuelTransactionHistoryFacade;
+import lk.gov.health.phsp.facade.FuelTransactionImageFacade;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -67,6 +69,8 @@ public class FuelRequestAndIssueController implements Serializable {
     BillFacade billFacade;
     @EJB
     BillItemFacade billItemFacade;
+    @EJB
+    private FuelTransactionImageFacade fuelTransactionImageFacade;
 
     @Inject
     private WebUserController webUserController;
@@ -3013,6 +3017,33 @@ public class FuelRequestAndIssueController implements Serializable {
             Logger.getLogger(this.getClass().getName()).log(Level.SEVERE, "Error downloading receipt", e);
             JsfUtil.addErrorMessage("Failed to download receipt. Please try again.");
         }
+    }
+
+    public org.primefaces.model.StreamedContent getFuelTransactionImage() {
+        FacesContext context = FacesContext.getCurrentInstance();
+        if (context.getRenderResponse()) {
+            return new org.primefaces.model.DefaultStreamedContent();
+        }
+        if (selected == null) {
+            return new org.primefaces.model.DefaultStreamedContent();
+        }
+        FuelTransactionImage image = fuelTransactionImageFacade.findByFuelTransaction(selected);
+        if (image == null || image.getImageData() == null) {
+            return new org.primefaces.model.DefaultStreamedContent();
+        }
+        return org.primefaces.model.DefaultStreamedContent.builder()
+                .stream(() -> new java.io.ByteArrayInputStream(image.getImageData()))
+                .contentType(image.getContentType() != null ? image.getContentType() : "image/jpeg")
+                .name(image.getFileName() != null ? image.getFileName() : "dispense_image.jpg")
+                .build();
+    }
+
+    public boolean hasFuelTransactionImage() {
+        if (selected == null) {
+            return false;
+        }
+        FuelTransactionImage image = fuelTransactionImageFacade.findByFuelTransaction(selected);
+        return image != null && image.getImageData() != null;
     }
 
     public org.primefaces.model.StreamedContent getCertifiedReceiptPreview() {

--- a/src/main/webapp/reports/request_delete.xhtml
+++ b/src/main/webapp/reports/request_delete.xhtml
@@ -222,6 +222,23 @@
                                                                 <td><b>Dispensing Comments:</b></td>
                                                                 <td><h:outputText value="#{reportController.fuelTransaction.dispensedComments}" /></td>
                                                             </tr>
+                                                            <ui:fragment rendered="#{reportController.hasFuelTransactionImage()}">
+                                                                <tr>
+                                                                    <td><b>Dispense Image:</b></td>
+                                                                    <td>
+                                                                        <p:graphicImage value="#{reportController.fuelTransactionImage}"
+                                                                                        style="max-width: 300px; max-height: 300px;"
+                                                                                        alt="Dispense Image" />
+                                                                        <br/>
+                                                                        <p:commandButton value="View Larger"
+                                                                                         icon="fa fa-search-plus"
+                                                                                         styleClass="ui-button-info ui-button-sm mt-2"
+                                                                                         oncomplete="PF('imageDialog').show();"
+                                                                                         update=":imageDialogForm"
+                                                                                         process="@this" />
+                                                                    </td>
+                                                                </tr>
+                                                            </ui:fragment>
                                                         </table>
                                                     </ui:fragment>
                                                     <ui:fragment rendered="#{!reportController.fuelTransaction.dispensed}">
@@ -339,6 +356,34 @@
 
                         </div>
                     </h:form>
+
+                    <!-- Dialog for viewing larger dispense image -->
+                    <p:dialog widgetVar="imageDialog"
+                              header="Dispense Image"
+                              modal="true"
+                              resizable="true"
+                              responsive="true"
+                              width="auto"
+                              height="auto">
+                        <h:form id="imageDialogForm">
+                            <div class="text-center p-3">
+                                <p:graphicImage
+                                    cache="false"
+                                    value="#{reportController.fuelTransactionImage}"
+                                    style="max-width: 90vw; max-height: 80vh;"
+                                    alt="Dispense Image"
+                                    rendered="#{reportController.hasFuelTransactionImage()}" />
+                                <div class="mt-3">
+                                    <p:commandButton value="Download"
+                                                     icon="fa fa-download"
+                                                     styleClass="ui-button-success"
+                                                     ajax="false">
+                                        <p:fileDownload value="#{reportController.fuelTransactionImage}" />
+                                    </p:commandButton>
+                                </div>
+                            </div>
+                        </h:form>
+                    </p:dialog>
                 </div>
 
             </ui:define>

--- a/src/main/webapp/reports/request_edit.xhtml
+++ b/src/main/webapp/reports/request_edit.xhtml
@@ -276,6 +276,23 @@
                                                                 <td><b>Dispensing Comments:</b></td>
                                                                 <td><h:outputText value="#{reportController.fuelTransaction.dispensedComments}" /></td>
                                                             </tr>
+                                                            <ui:fragment rendered="#{reportController.hasFuelTransactionImage()}">
+                                                                <tr>
+                                                                    <td><b>Dispense Image:</b></td>
+                                                                    <td>
+                                                                        <p:graphicImage value="#{reportController.fuelTransactionImage}"
+                                                                                        style="max-width: 300px; max-height: 300px;"
+                                                                                        alt="Dispense Image" />
+                                                                        <br/>
+                                                                        <p:commandButton value="View Larger"
+                                                                                         icon="fa fa-search-plus"
+                                                                                         styleClass="ui-button-info ui-button-sm mt-2"
+                                                                                         oncomplete="PF('imageDialog').show();"
+                                                                                         update=":imageDialogForm"
+                                                                                         process="@this" />
+                                                                    </td>
+                                                                </tr>
+                                                            </ui:fragment>
                                                         </table>
                                                     </ui:fragment>
                                                     <ui:fragment rendered="#{!reportController.fuelTransaction.dispensed}">
@@ -393,6 +410,34 @@
 
                         </div>
                     </h:form>
+
+                    <!-- Dialog for viewing larger dispense image -->
+                    <p:dialog widgetVar="imageDialog"
+                              header="Dispense Image"
+                              modal="true"
+                              resizable="true"
+                              responsive="true"
+                              width="auto"
+                              height="auto">
+                        <h:form id="imageDialogForm">
+                            <div class="text-center p-3">
+                                <p:graphicImage
+                                    cache="false"
+                                    value="#{reportController.fuelTransactionImage}"
+                                    style="max-width: 90vw; max-height: 80vh;"
+                                    alt="Dispense Image"
+                                    rendered="#{reportController.hasFuelTransactionImage()}" />
+                                <div class="mt-3">
+                                    <p:commandButton value="Download"
+                                                     icon="fa fa-download"
+                                                     styleClass="ui-button-success"
+                                                     ajax="false">
+                                        <p:fileDownload value="#{reportController.fuelTransactionImage}" />
+                                    </p:commandButton>
+                                </div>
+                            </div>
+                        </h:form>
+                    </p:dialog>
                 </div>
 
             </ui:define>

--- a/src/main/webapp/reports/request_view.xhtml
+++ b/src/main/webapp/reports/request_view.xhtml
@@ -140,7 +140,7 @@
                                                                 <td><b>Confirmed Quantity:</b></td>
                                                                 <td><h:outputText value="#{reportController.fuelTransaction.issuedQuantity}" /></td>
                                                             </tr>
-                                                             <tr>
+                                                            <tr>
                                                                 <td><b>Invoice No:</b></td>
                                                                 <td><h:outputText value="#{reportController.fuelTransaction.issueReferenceNumber}" /></td>
                                                             </tr>
@@ -354,10 +354,12 @@
                               height="auto">
                         <h:form id="imageDialogForm">
                             <div class="text-center p-3">
-                                <p:graphicImage value="#{reportController.fuelTransactionImage}"
-                                                style="max-width: 90vw; max-height: 80vh;"
-                                                alt="Dispense Image"
-                                                rendered="#{reportController.hasFuelTransactionImage()}" />
+                                <p:graphicImage
+                                    cache="false"
+                                    value="#{reportController.fuelTransactionImage}"
+                                    style="max-width: 90vw; max-height: 80vh;"
+                                    alt="Dispense Image"
+                                    rendered="#{reportController.hasFuelTransactionImage()}" />
                                 <div class="mt-3">
                                     <p:commandButton value="Download"
                                                      icon="fa fa-download"

--- a/src/main/webapp/requests/mark.xhtml
+++ b/src/main/webapp/requests/mark.xhtml
@@ -229,6 +229,23 @@
                                                                     <td><b>Dispensing Comments:</b></td>
                                                                     <td><h:outputText value="#{fuelRequestAndIssueController.selected.dispensedComments}" /></td>
                                                                 </tr>
+                                                                <ui:fragment rendered="#{fuelRequestAndIssueController.hasFuelTransactionImage()}">
+                                                                    <tr>
+                                                                        <td><b>Dispense Image:</b></td>
+                                                                        <td>
+                                                                            <p:graphicImage value="#{fuelRequestAndIssueController.fuelTransactionImage}"
+                                                                                            style="max-width: 300px; max-height: 300px;"
+                                                                                            alt="Dispense Image" />
+                                                                            <br/>
+                                                                            <p:commandButton value="View Larger"
+                                                                                             icon="fa fa-search-plus"
+                                                                                             styleClass="ui-button-info ui-button-sm mt-2"
+                                                                                             oncomplete="PF('imageDialog').show();"
+                                                                                             update=":imageDialogForm"
+                                                                                             process="@this" />
+                                                                        </td>
+                                                                    </tr>
+                                                                </ui:fragment>
                                                             </table>
                                                         </ui:fragment>
                                                         <ui:fragment rendered="#{!fuelRequestAndIssueController.selected.dispensed}">
@@ -334,6 +351,34 @@
 
                         </div>
                     </h:form>
+
+                    <!-- Dialog for viewing larger dispense image -->
+                    <p:dialog widgetVar="imageDialog"
+                              header="Dispense Image"
+                              modal="true"
+                              resizable="true"
+                              responsive="true"
+                              width="auto"
+                              height="auto">
+                        <h:form id="imageDialogForm">
+                            <div class="text-center p-3">
+                                <p:graphicImage
+                                    cache="false"
+                                    value="#{fuelRequestAndIssueController.fuelTransactionImage}"
+                                    style="max-width: 90vw; max-height: 80vh;"
+                                    alt="Dispense Image"
+                                    rendered="#{fuelRequestAndIssueController.hasFuelTransactionImage()}" />
+                                <div class="mt-3">
+                                    <p:commandButton value="Download"
+                                                     icon="fa fa-download"
+                                                     styleClass="ui-button-success"
+                                                     ajax="false">
+                                        <p:fileDownload value="#{fuelRequestAndIssueController.fuelTransactionImage}" />
+                                    </p:commandButton>
+                                </div>
+                            </div>
+                        </h:form>
+                    </p:dialog>
                 </div>
 
             </ui:define>

--- a/src/main/webapp/requests/requested.xhtml
+++ b/src/main/webapp/requests/requested.xhtml
@@ -236,6 +236,23 @@
                                                                 <td><b>Dispensing Comments:</b></td>
                                                                 <td><h:outputText value="#{fuelRequestAndIssueController.selected.dispensedComments}" /></td>
                                                             </tr>
+                                                            <ui:fragment rendered="#{fuelRequestAndIssueController.hasFuelTransactionImage()}">
+                                                                <tr>
+                                                                    <td><b>Dispense Image:</b></td>
+                                                                    <td>
+                                                                        <p:graphicImage value="#{fuelRequestAndIssueController.fuelTransactionImage}"
+                                                                                        style="max-width: 300px; max-height: 300px;"
+                                                                                        alt="Dispense Image" />
+                                                                        <br/>
+                                                                        <p:commandButton value="View Larger"
+                                                                                         icon="fa fa-search-plus"
+                                                                                         styleClass="ui-button-info ui-button-sm mt-2"
+                                                                                         oncomplete="PF('imageDialog').show();"
+                                                                                         update=":imageDialogForm"
+                                                                                         process="@this" />
+                                                                    </td>
+                                                                </tr>
+                                                            </ui:fragment>
                                                         </table>
                                                     </ui:fragment>
                                                     <ui:fragment rendered="#{!fuelRequestAndIssueController.selected.dispensed}">
@@ -351,6 +368,34 @@
 
                         </div>
                     </h:form>
+
+                    <!-- Dialog for viewing larger dispense image -->
+                    <p:dialog widgetVar="imageDialog"
+                              header="Dispense Image"
+                              modal="true"
+                              resizable="true"
+                              responsive="true"
+                              width="auto"
+                              height="auto">
+                        <h:form id="imageDialogForm">
+                            <div class="text-center p-3">
+                                <p:graphicImage
+                                    cache="false"
+                                    value="#{fuelRequestAndIssueController.fuelTransactionImage}"
+                                    style="max-width: 90vw; max-height: 80vh;"
+                                    alt="Dispense Image"
+                                    rendered="#{fuelRequestAndIssueController.hasFuelTransactionImage()}" />
+                                <div class="mt-3">
+                                    <p:commandButton value="Download"
+                                                     icon="fa fa-download"
+                                                     styleClass="ui-button-success"
+                                                     ajax="false">
+                                        <p:fileDownload value="#{fuelRequestAndIssueController.fuelTransactionImage}" />
+                                    </p:commandButton>
+                                </div>
+                            </div>
+                        </h:form>
+                    </p:dialog>
                 </div>
 
             </ui:define>


### PR DESCRIPTION
## Summary
- Adds the dispense invoice image (uploaded from the mobile app) to the four other fuel-transaction detail pages — `reports/request_edit.xhtml`, `reports/request_delete.xhtml`, `requests/requested.xhtml`, `requests/mark.xhtml` — so users see the receipt wherever they view a transaction. Previously only `reports/request_view.xhtml` showed it.
- Each page renders a thumbnail inside the existing Dispensing Details table when an image is present, plus a "View Larger" button that opens a modal preview with a Download action.
- Adds `getFuelTransactionImage()` / `hasFuelTransactionImage()` to `FuelRequestAndIssueController` so the `requests/*` pages (which use `fuelRequestAndIssueController.selected`) can stream the image. `ReportController` already exposed equivalents.
- Sets `cache="false"` on the existing `reports/request_view.xhtml` modal `p:graphicImage` so it does not reuse a stale stream.

## Test plan
- [ ] Open a dispensed fuel transaction in `reports/request_view.xhtml` — receipt thumbnail and "View Larger" still work.
- [ ] Open the same transaction in `reports/request_edit.xhtml` — receipt thumbnail visible inside Dispensing Details; modal preview opens.
- [ ] Open the same transaction in `reports/request_delete.xhtml` — same as above.
- [ ] Open in `requests/requested.xhtml` — receipt thumbnail and modal work.
- [ ] Open in `requests/mark.xhtml` — receipt thumbnail and modal work.
- [ ] Open a transaction with no dispense image — image row is hidden on every page.
- [ ] Open an undispensed transaction — Dispensing Details fragment is hidden as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)