### PR TITLE
Validate fuel request quantity against vehicle type limit

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
@@ -37,6 +37,7 @@ import lk.gov.health.phsp.entity.Vehicle;
 import lk.gov.health.phsp.entity.WebUser;
 import lk.gov.health.phsp.enums.DataAlterationRequestType;
 import lk.gov.health.phsp.enums.FuelTransactionType;
+import lk.gov.health.phsp.enums.VehicleType;
 import lk.gov.health.phsp.facade.BillFacade;
 import lk.gov.health.phsp.facade.BillItemFacade;
 import lk.gov.health.phsp.facade.DataAlterationRequestFacade;
@@ -479,9 +480,10 @@ public class FuelRequestAndIssueController implements Serializable {
             return "";
         }
 
-        // Validation 5: Check if request quantity exceeds vehicle fuel capacity
-        if (!isRequestQuantityWithinCapacity(selected.getVehicle(), selected.getRequestQuantity())) {
-            JsfUtil.addErrorMessage("Requested quantity (" + selected.getRequestQuantity() + " liters) exceeds the vehicle's fuel tank capacity (" + selected.getVehicle().getFuelCapacity() + " liters)");
+        // Validation 5: Check if request quantity exceeds the vehicle type's maximum
+        if (!isRequestQuantityWithinTypeLimit(selected.getVehicle(), selected.getRequestQuantity())) {
+            VehicleType vt = selected.getVehicle().getVehicleType();
+            JsfUtil.addErrorMessage("Requested quantity (" + selected.getRequestQuantity() + " liters) exceeds the maximum allowed for vehicle type " + vt.getLabel() + " (" + vt.getMaxRequestQuantity() + " liters)");
             return "";
         }
 
@@ -558,9 +560,10 @@ public class FuelRequestAndIssueController implements Serializable {
             return "";
         }
 
-        // Validation 5: Check if request quantity exceeds vehicle fuel capacity
-        if (!isRequestQuantityWithinCapacity(selected.getVehicle(), selected.getRequestQuantity())) {
-            JsfUtil.addErrorMessage("Requested quantity (" + selected.getRequestQuantity() + " liters) exceeds the vehicle's fuel tank capacity (" + selected.getVehicle().getFuelCapacity() + " liters)");
+        // Validation 5: Check if request quantity exceeds the vehicle type's maximum
+        if (!isRequestQuantityWithinTypeLimit(selected.getVehicle(), selected.getRequestQuantity())) {
+            VehicleType vt = selected.getVehicle().getVehicleType();
+            JsfUtil.addErrorMessage("Requested quantity (" + selected.getRequestQuantity() + " liters) exceeds the maximum allowed for vehicle type " + vt.getLabel() + " (" + vt.getMaxRequestQuantity() + " liters)");
             return "";
         }
 
@@ -2694,19 +2697,21 @@ public class FuelRequestAndIssueController implements Serializable {
         }
     }
 
-    private boolean isRequestQuantityWithinCapacity(Vehicle vehicle, Double requestQuantity) {
+    private boolean isRequestQuantityWithinTypeLimit(Vehicle vehicle, Double requestQuantity) {
         // Skip validation if vehicle or request quantity is null
         if (vehicle == null || requestQuantity == null) {
             return true;
         }
 
-        // Skip validation if fuel capacity is not set for the vehicle
-        if (vehicle.getFuelCapacity() == null) {
+        VehicleType vehicleType = vehicle.getVehicleType();
+
+        // Skip validation if no type, or the type has no configured limit (null = no limit)
+        if (vehicleType == null || vehicleType.getMaxRequestQuantity() == null) {
             return true;
         }
 
-        // Check if request quantity exceeds fuel capacity
-        return requestQuantity <= vehicle.getFuelCapacity();
+        // Check if request quantity exceeds the maximum allowed for this vehicle type
+        return requestQuantity <= vehicleType.getMaxRequestQuantity();
     }
 
     private boolean areDatesInSameMonth(Date fromDate, Date toDate) {

--- a/src/main/java/lk/gov/health/phsp/bean/ReportController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/ReportController.java
@@ -2062,9 +2062,10 @@ public class ReportController implements Serializable {
             }
         }
 
-        // Validation 4: Check if request quantity exceeds vehicle fuel capacity
-        if (!isRequestQuantityWithinCapacity(fuelTransaction.getVehicle(), fuelTransaction.getRequestQuantity())) {
-            JsfUtil.addErrorMessage("Requested quantity (" + fuelTransaction.getRequestQuantity() + " liters) exceeds the vehicle's fuel tank capacity (" + fuelTransaction.getVehicle().getFuelCapacity() + " liters)");
+        // Validation 4: Check if request quantity exceeds the vehicle type's maximum
+        if (!isRequestQuantityWithinTypeLimit(fuelTransaction.getVehicle(), fuelTransaction.getRequestQuantity())) {
+            VehicleType vt = fuelTransaction.getVehicle().getVehicleType();
+            JsfUtil.addErrorMessage("Requested quantity (" + fuelTransaction.getRequestQuantity() + " liters) exceeds the maximum allowed for vehicle type " + vt.getLabel() + " (" + vt.getMaxRequestQuantity() + " liters)");
             return;
         }
 
@@ -2145,19 +2146,21 @@ public class ReportController implements Serializable {
         return true;
     }
 
-    private boolean isRequestQuantityWithinCapacity(Vehicle vehicle, Double requestQuantity) {
+    private boolean isRequestQuantityWithinTypeLimit(Vehicle vehicle, Double requestQuantity) {
         // Skip validation if vehicle or request quantity is null
         if (vehicle == null || requestQuantity == null) {
             return true;
         }
 
-        // Skip validation if fuel capacity is not set for the vehicle
-        if (vehicle.getFuelCapacity() == null) {
+        VehicleType vehicleType = vehicle.getVehicleType();
+
+        // Skip validation if no type, or the type has no configured limit (null = no limit)
+        if (vehicleType == null || vehicleType.getMaxRequestQuantity() == null) {
             return true;
         }
 
-        // Check if request quantity exceeds fuel capacity
-        return requestQuantity <= vehicle.getFuelCapacity();
+        // Check if request quantity exceeds the maximum allowed for this vehicle type
+        return requestQuantity <= vehicleType.getMaxRequestQuantity();
     }
 
     private Double getPreviousOdoReading(Vehicle vehicle, Long currentTransactionId) {

--- a/src/main/java/lk/gov/health/phsp/enums/VehicleType.java
+++ b/src/main/java/lk/gov/health/phsp/enums/VehicleType.java
@@ -8,30 +8,35 @@ package lk.gov.health.phsp.enums;
  * @author Dr M H B Ariyaratne
  */
 public enum VehicleType {
-    Ambulance("Ambulance", true, "rgba(255, 99, 132, 0.6)"),
-    Bowser("Bowser", true, "rgba(54, 162, 235, 0.6)"),
-    Bus("Bus", true, "rgba(255, 206, 86, 0.6)"),
-    Cab("Cab", true, "rgba(75, 192, 192, 0.6)"),
-    Car("Car", true, "rgba(153, 102, 255, 0.6)"),
-    FoggingMachine("Fogging Machine", false, "rgba(255, 159, 64, 0.6)"),
-    Generator("Generator", false, "rgba(199, 199, 199, 0.6)"), // Example of a lighter shade for non-vehicle items
-    GullyBowser("Gully Bowser", true, "rgba(255, 129, 102, 0.6)"),
-    Incinerator("Incinerator", false, "rgba(220, 20, 60, 0.6)"),
-    ServiceStation("Service Station", false, "rgba(200, 60, 60, 0.6)"),
-    Jeep("Jeep", true, "rgba(0, 255, 255, 0.6)"),
-    Lorry("Lorry", true, "rgba(0, 0, 128, 0.6)"),
-    ThreeWheeler("Three Wheeler", true, "rgba(128, 0, 128, 0.6)"),
-    Tractor("Tractor", true, "rgba(128, 128, 0, 0.6)"),
-    Van("Van", true, "rgba(0, 128, 0, 0.6)");
+    // maxRequestQuantity = maximum fuel (liters) allowed per request order for this type.
+    // null means no limit (any quantity allowed). Values are policy limits and are
+    // very unlikely to change; update them here if the policy changes.
+    Ambulance("Ambulance", true, "rgba(255, 99, 132, 0.6)", 95.0),
+    Bowser("Bowser", true, "rgba(54, 162, 235, 0.6)", 100.0), // same limit as Gully Bowser
+    Bus("Bus", true, "rgba(255, 206, 86, 0.6)", 350.0),
+    Cab("Cab", true, "rgba(75, 192, 192, 0.6)", 80.0),
+    Car("Car", true, "rgba(153, 102, 255, 0.6)", 50.0),
+    FoggingMachine("Fogging Machine", false, "rgba(255, 159, 64, 0.6)", 40.0),
+    Generator("Generator", false, "rgba(199, 199, 199, 0.6)", 100.0), // Example of a lighter shade for non-vehicle items
+    GullyBowser("Gully Bowser", true, "rgba(255, 129, 102, 0.6)", 100.0),
+    Incinerator("Incinerator", false, "rgba(220, 20, 60, 0.6)", 500.0),
+    ServiceStation("Service Station", false, "rgba(200, 60, 60, 0.6)", null), // no limit
+    Jeep("Jeep", true, "rgba(0, 255, 255, 0.6)", 110.0),
+    Lorry("Lorry", true, "rgba(0, 0, 128, 0.6)", 300.0),
+    ThreeWheeler("Three Wheeler", true, "rgba(128, 0, 128, 0.6)", 8.0),
+    Tractor("Tractor", true, "rgba(128, 128, 0, 0.6)", 60.0),
+    Van("Van", true, "rgba(0, 128, 0, 0.6)", 70.0);
 
     private final String label;
     private final boolean isVehicle;
     private final String color; // New field to store the color
+    private final Double maxRequestQuantity; // max liters allowed per request order; null = no limit
 
-    private VehicleType(String label, boolean isVehicle, String color) {
+    private VehicleType(String label, boolean isVehicle, String color, Double maxRequestQuantity) {
         this.label = label;
         this.isVehicle = isVehicle;
         this.color = color;
+        this.maxRequestQuantity = maxRequestQuantity;
     }
 
     public String getLabel() {
@@ -44,5 +49,9 @@ public enum VehicleType {
 
     public String getColor() {
         return color;
+    }
+
+    public Double getMaxRequestQuantity() {
+        return maxRequestQuantity;
     }
 }


### PR DESCRIPTION
## Summary
Replaces the per-vehicle **fuel tank capacity** check with a per-**vehicle-type** maximum request quantity. Limits are policy values defined on the `VehicleType` enum (very unlikely to change; edit the enum if they do). A `null` limit means no restriction.

## Changes
- **`enums/VehicleType.java`** — add `maxRequestQuantity` (liters) to each constant + `getMaxRequestQuantity()`.
  - Ambulance 95 · Bowser 100 · Bus 350 · Cab 80 · Car 50 · Fogging Machine 40 · Generator 100 · Gully Bowser 100 · Incinerator 500 · Jeep 110 · Lorry 300 · Three Wheeler 8 · Tractor 60 · Van 70 · **Service Station = no limit**
- **`bean/FuelRequestAndIssueController.java`** & **`bean/ReportController.java`** — rename `isRequestQuantityWithinCapacity` → `isRequestQuantityWithinTypeLimit`, validate `requestQuantity <= type max`, skip when type/limit is null. Clearer error: *"Requested quantity (X liters) exceeds the maximum allowed for vehicle type Ambulance (95.0 liters)"*.

## Notes
- No DB/schema change. The per-vehicle `fuelCapacity` field is left intact, just no longer used for this validation.
- Vehicles with no type, or a type with no limit (Service Station), are allowed any quantity (matches prior skip-when-null behavior).
- **Not in scope:** mobile/REST creation paths (`RestQrScanController`, `FuelDispenseController`, `ApiResource`) still run no quantity-limit validation, same as before. Can be extended via a shared helper if server-side enforcement on those paths is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)