### PR TITLE
Fuel-order validations for the production line

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
@@ -7,6 +7,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -31,6 +32,7 @@ import lk.gov.health.phsp.entity.Vehicle;
 import lk.gov.health.phsp.entity.WebUser;
 import lk.gov.health.phsp.enums.DataAlterationRequestType;
 import lk.gov.health.phsp.enums.FuelTransactionType;
+import lk.gov.health.phsp.enums.VehicleType;
 import lk.gov.health.phsp.facade.BillFacade;
 import lk.gov.health.phsp.facade.DataAlterationRequestFacade;
 import lk.gov.health.phsp.facade.FuelTransactionFacade;
@@ -376,9 +378,52 @@ public class FuelRequestAndIssueController implements Serializable {
             JsfUtil.addErrorMessage("Enter a referance number");
             return "";
         }
+        if (selected.getOdoMeterReading() == null) {
+            JsfUtil.addErrorMessage("ODO Meter Reading is required");
+            return "";
+        }
+        if (selected.getRequestQuantity() == null) {
+            JsfUtil.addErrorMessage("Request Quantity is required");
+            return "";
+        }
+
+        // Validation 1: Reference number must be unique within the same month for this institution
+        if (!isReferenceNumberUnique(selected.getRequestReferenceNumber(), webUserController.getLoggedInstitution(), selected.getRequestedDate())) {
+            JsfUtil.addErrorMessage("Reference number '" + selected.getRequestReferenceNumber() + "' has already been used this month for this institution");
+            return "";
+        }
+
+        // Validation 2: Reference number, ODO meter and request quantity must be different numbers
+        if (!areFieldValuesDistinct(selected.getRequestReferenceNumber(), selected.getOdoMeterReading(), selected.getRequestQuantity())) {
+            JsfUtil.addErrorMessage("Request Reference Number, ODO Meter Reading and Request Quantity must be different numbers");
+            return "";
+        }
+
+        // Validation 3: ODO reading must be greater than the previous reading
+        Double previousOdoReading = getPreviousOdoReading(selected.getVehicle());
+        if (previousOdoReading != null && selected.getOdoMeterReading() != null) {
+            if (selected.getOdoMeterReading() <= previousOdoReading) {
+                JsfUtil.addErrorMessage("ODO Meter Reading (" + selected.getOdoMeterReading() + ") must be greater than the previous reading (" + previousOdoReading + ")");
+                return "";
+            }
+        }
+
+        // Validation 4: Only one pending (not yet issued) fuel request per vehicle
+        if (hasPendingRequest(selected.getVehicle())) {
+            JsfUtil.addErrorMessage("This vehicle already has a pending fuel request that has not been issued yet. Please wait for that request to be issued first.");
+            return "";
+        }
+
+        // Validation 5: Request quantity must not exceed the vehicle type's maximum
+        if (!isRequestQuantityWithinTypeLimit(selected.getVehicle(), selected.getRequestQuantity())) {
+            VehicleType vt = selected.getVehicle().getVehicleType();
+            JsfUtil.addErrorMessage("Requested quantity (" + selected.getRequestQuantity() + " liters) exceeds the maximum allowed for vehicle type " + vt.getLabel() + " (" + vt.getMaxRequestQuantity() + " liters)");
+            return "";
+        }
+
         selected.setRequestAt(new Date());
         save(selected);
-        JsfUtil.addSuccessMessage("Request Submitted");
+        JsfUtil.addSuccessMessage("Fuel request submitted successfully. Reference number: " + selected.getRequestReferenceNumber());
         return navigateToViewInstitutionFuelRequestToSltbDepot();
     }
 
@@ -407,6 +452,53 @@ public class FuelRequestAndIssueController implements Serializable {
             JsfUtil.addErrorMessage("Enter Requested Date");
             return "";
         }
+        if (selected.getRequestReferenceNumber() == null || selected.getRequestReferenceNumber().trim().equals("")) {
+            JsfUtil.addErrorMessage("Enter a referance number");
+            return "";
+        }
+        if (selected.getOdoMeterReading() == null) {
+            JsfUtil.addErrorMessage("ODO Meter Reading is required");
+            return "";
+        }
+        if (selected.getRequestQuantity() == null) {
+            JsfUtil.addErrorMessage("Request Quantity is required");
+            return "";
+        }
+
+        // Validation 1: Reference number must be unique within the same month for this institution
+        if (!isReferenceNumberUnique(selected.getRequestReferenceNumber(), selected.getVehicle().getInstitution(), selected.getRequestedDate())) {
+            JsfUtil.addErrorMessage("Reference number '" + selected.getRequestReferenceNumber() + "' has already been used this month for this institution");
+            return "";
+        }
+
+        // Validation 2: Reference number, ODO meter and request quantity must be different numbers
+        if (!areFieldValuesDistinct(selected.getRequestReferenceNumber(), selected.getOdoMeterReading(), selected.getRequestQuantity())) {
+            JsfUtil.addErrorMessage("Request Reference Number, ODO Meter Reading and Request Quantity must be different numbers");
+            return "";
+        }
+
+        // Validation 3: ODO reading must be greater than the previous reading
+        Double previousOdoReading = getPreviousOdoReading(selected.getVehicle());
+        if (previousOdoReading != null && selected.getOdoMeterReading() != null) {
+            if (selected.getOdoMeterReading() <= previousOdoReading) {
+                JsfUtil.addErrorMessage("ODO Meter Reading (" + selected.getOdoMeterReading() + ") must be greater than the previous reading (" + previousOdoReading + ")");
+                return "";
+            }
+        }
+
+        // Validation 4: Only one pending (not yet issued) fuel request per vehicle
+        if (hasPendingRequest(selected.getVehicle())) {
+            JsfUtil.addErrorMessage("This vehicle already has a pending fuel request that has not been issued yet. Please wait for that request to be issued first.");
+            return "";
+        }
+
+        // Validation 5: Request quantity must not exceed the vehicle type's maximum
+        if (!isRequestQuantityWithinTypeLimit(selected.getVehicle(), selected.getRequestQuantity())) {
+            VehicleType vt = selected.getVehicle().getVehicleType();
+            JsfUtil.addErrorMessage("Requested quantity (" + selected.getRequestQuantity() + " liters) exceeds the maximum allowed for vehicle type " + vt.getLabel() + " (" + vt.getMaxRequestQuantity() + " liters)");
+            return "";
+        }
+
         selected.setInstitution(selected.getVehicle().getInstitution());
         if (selected.getTxDate() == null) {
             selected.setTxDate(new Date());
@@ -416,8 +508,136 @@ public class FuelRequestAndIssueController implements Serializable {
         }
         selected.setRequestAt(new Date());
         save(selected);
-        JsfUtil.addSuccessMessage("Special Fuel Request Submitted");
+        JsfUtil.addSuccessMessage("Special fuel request submitted successfully. Reference number: " + selected.getRequestReferenceNumber());
         return navigateToViewInstitutionFuelRequestToSltbDepot();
+    }
+
+    // ===== Fuel order validation helpers =====
+
+    private boolean isReferenceNumberUnique(String referenceNumber, Institution institution, Date referenceDate) {
+        if (referenceNumber == null || referenceNumber.trim().isEmpty() || institution == null) {
+            return true;
+        }
+
+        // Determine the calendar month of the order (start inclusive, next month start exclusive)
+        Date basisDate = (referenceDate != null) ? referenceDate : new Date();
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(basisDate);
+        cal.set(Calendar.DAY_OF_MONTH, 1);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date monthStart = cal.getTime();
+        cal.add(Calendar.MONTH, 1);
+        Date nextMonthStart = cal.getTime();
+
+        // Count orders with the same reference number in the same calendar month for this
+        // institution, including active AND inactive (retired/cancelled/rejected) orders.
+        String jpql = "SELECT COUNT(ft) FROM FuelTransaction ft "
+                + "WHERE ft.requestReferenceNumber = :refNum "
+                + "AND ft.fromInstitution = :institution "
+                + "AND ft.requestedDate >= :monthStart "
+                + "AND ft.requestedDate < :nextMonthStart";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("refNum", referenceNumber.trim());
+        params.put("institution", institution);
+        params.put("monthStart", monthStart);
+        params.put("nextMonthStart", nextMonthStart);
+
+        Long count = fuelTransactionFacade.countByJpql(jpql, params);
+        return count == null || count == 0;
+    }
+
+    private boolean areFieldValuesDistinct(String referenceNumber, Double odoReading, Double requestQuantity) {
+        if (referenceNumber == null || odoReading == null || requestQuantity == null) {
+            return true; // Skip validation if any value is null
+        }
+
+        try {
+            Double refNumAsDouble = Double.parseDouble(referenceNumber.trim());
+            // Check if reference number equals request quantity or ODO reading
+            if (refNumAsDouble.equals(requestQuantity) || refNumAsDouble.equals(odoReading)) {
+                return false;
+            }
+        } catch (NumberFormatException e) {
+            // Reference number is not numeric, which is fine
+        }
+
+        // Check if ODO reading equals request quantity
+        if (odoReading.equals(requestQuantity)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private Double getPreviousOdoReading(Vehicle vehicle) {
+        if (vehicle == null || vehicle.getId() == null) {
+            return null;
+        }
+
+        try {
+            String jpql = "SELECT ft FROM FuelTransaction ft "
+                    + "WHERE ft.vehicle.id = :vehicleId "
+                    + "AND ft.retired = false "
+                    + "AND ft.odoMeterReading IS NOT NULL "
+                    + "ORDER BY ft.requestedDate DESC";
+
+            Map<String, Object> params = new HashMap<>();
+            params.put("vehicleId", vehicle.getId());
+
+            List<FuelTransaction> results = fuelTransactionFacade.findByJpql(jpql, params, 1);
+            if (results != null && !results.isEmpty()) {
+                return results.get(0).getOdoMeterReading();
+            }
+        } catch (Exception e) {
+            Logger.getLogger(FuelRequestAndIssueController.class.getName()).log(Level.SEVERE, "Error getting previous ODO reading for vehicle: " + vehicle.getId(), e);
+        }
+        return null;
+    }
+
+    private boolean hasPendingRequest(Vehicle vehicle) {
+        if (vehicle == null || vehicle.getId() == null) {
+            return false;
+        }
+
+        try {
+            // A request is "pending" until it is issued (production has no separate dispensed step)
+            String jpql = "SELECT COUNT(ft) FROM FuelTransaction ft "
+                    + "WHERE ft.vehicle.id = :vehicleId "
+                    + "AND ft.issued = false "
+                    + "AND ft.rejected = false "
+                    + "AND ft.cancelled = false "
+                    + "AND ft.retired = false";
+
+            Map<String, Object> params = new HashMap<>();
+            params.put("vehicleId", vehicle.getId());
+
+            Long count = fuelTransactionFacade.countByJpql(jpql, params);
+            return count != null && count > 0;
+        } catch (Exception e) {
+            Logger.getLogger(FuelRequestAndIssueController.class.getName()).log(Level.SEVERE, "Error checking pending request for vehicle: " + vehicle.getId(), e);
+            return false;
+        }
+    }
+
+    private boolean isRequestQuantityWithinTypeLimit(Vehicle vehicle, Double requestQuantity) {
+        // Skip validation if vehicle or request quantity is null
+        if (vehicle == null || requestQuantity == null) {
+            return true;
+        }
+
+        VehicleType vehicleType = vehicle.getVehicleType();
+
+        // Skip validation if no type, or the type has no configured limit (null = no limit)
+        if (vehicleType == null || vehicleType.getMaxRequestQuantity() == null) {
+            return true;
+        }
+
+        // Check if request quantity exceeds the maximum allowed for this vehicle type
+        return requestQuantity <= vehicleType.getMaxRequestQuantity();
     }
 
     public String submitSltbFuelRequestFromCpc() {

--- a/src/main/java/lk/gov/health/phsp/enums/VehicleType.java
+++ b/src/main/java/lk/gov/health/phsp/enums/VehicleType.java
@@ -8,30 +8,35 @@ package lk.gov.health.phsp.enums;
  * @author Dr M H B Ariyaratne
  */
 public enum VehicleType {
-    Ambulance("Ambulance", true, "rgba(255, 99, 132, 0.6)"),
-    Bowser("Bowser", true, "rgba(54, 162, 235, 0.6)"),
-    Bus("Bus", true, "rgba(255, 206, 86, 0.6)"),
-    Cab("Cab", true, "rgba(75, 192, 192, 0.6)"),
-    Car("Car", true, "rgba(153, 102, 255, 0.6)"),
-    FoggingMachine("Fogging Machine", false, "rgba(255, 159, 64, 0.6)"),
-    Generator("Generator", false, "rgba(199, 199, 199, 0.6)"), // Example of a lighter shade for non-vehicle items
-    GullyBowser("Gully Bowser", true, "rgba(255, 129, 102, 0.6)"),
-    Incinerator("Incinerator", false, "rgba(220, 20, 60, 0.6)"),
-    ServiceStation("Service Station", false, "rgba(200, 60, 60, 0.6)"),
-    Jeep("Jeep", true, "rgba(0, 255, 255, 0.6)"),
-    Lorry("Lorry", true, "rgba(0, 0, 128, 0.6)"),
-    ThreeWheeler("Three Wheeler", true, "rgba(128, 0, 128, 0.6)"),
-    Tractor("Tractor", true, "rgba(128, 128, 0, 0.6)"),
-    Van("Van", true, "rgba(0, 128, 0, 0.6)");
+    // maxRequestQuantity = maximum fuel (liters) allowed per request order for this type.
+    // null means no limit (any quantity allowed). Values are policy limits and are
+    // very unlikely to change; update them here if the policy changes.
+    Ambulance("Ambulance", true, "rgba(255, 99, 132, 0.6)", 95.0),
+    Bowser("Bowser", true, "rgba(54, 162, 235, 0.6)", 100.0), // same limit as Gully Bowser
+    Bus("Bus", true, "rgba(255, 206, 86, 0.6)", 350.0),
+    Cab("Cab", true, "rgba(75, 192, 192, 0.6)", 80.0),
+    Car("Car", true, "rgba(153, 102, 255, 0.6)", 50.0),
+    FoggingMachine("Fogging Machine", false, "rgba(255, 159, 64, 0.6)", 40.0),
+    Generator("Generator", false, "rgba(199, 199, 199, 0.6)", 100.0), // Example of a lighter shade for non-vehicle items
+    GullyBowser("Gully Bowser", true, "rgba(255, 129, 102, 0.6)", 100.0),
+    Incinerator("Incinerator", false, "rgba(220, 20, 60, 0.6)", 500.0),
+    ServiceStation("Service Station", false, "rgba(200, 60, 60, 0.6)", null), // no limit
+    Jeep("Jeep", true, "rgba(0, 255, 255, 0.6)", 110.0),
+    Lorry("Lorry", true, "rgba(0, 0, 128, 0.6)", 300.0),
+    ThreeWheeler("Three Wheeler", true, "rgba(128, 0, 128, 0.6)", 8.0),
+    Tractor("Tractor", true, "rgba(128, 128, 0, 0.6)", 60.0),
+    Van("Van", true, "rgba(0, 128, 0, 0.6)", 70.0);
 
     private final String label;
     private final boolean isVehicle;
     private final String color; // New field to store the color
+    private final Double maxRequestQuantity; // max liters allowed per request order; null = no limit
 
-    private VehicleType(String label, boolean isVehicle, String color) {
+    private VehicleType(String label, boolean isVehicle, String color, Double maxRequestQuantity) {
         this.label = label;
         this.isVehicle = isVehicle;
         this.color = color;
+        this.maxRequestQuantity = maxRequestQuantity;
     }
 
     public String getLabel() {
@@ -44,5 +49,9 @@ public enum VehicleType {
 
     public String getColor() {
         return color;
+    }
+
+    public Double getMaxRequestQuantity() {
+        return maxRequestQuantity;
     }
 }

--- a/src/main/webapp/requests/request.xhtml
+++ b/src/main/webapp/requests/request.xhtml
@@ -17,6 +17,7 @@
             <ui:define name="content">
                 <div class="container p-1" >
                     <h:form >
+                        <p:messages id="msgs" showDetail="true" closable="true" />
                         <div class="row justify-content-md-center" >
                             <div class="col-12 col-md-10 col-lg-8" >
 
@@ -25,11 +26,12 @@
                                     <f:facet name="header" >
                                         <h2>
                                             <h:outputText value="Vehicle Fuel Request"></h:outputText>
-                                            <h:commandButton  value="Submit" 
-                                                              class="btn btn-primary"
-                                                              style="float: right;"
-                                                              action="#{fuelRequestAndIssueController.submitVehicleFuelRequest()}" >
-                                            </h:commandButton>
+                                            <p:commandButton value="Submit"
+                                                             styleClass="btn btn-primary"
+                                                             style="float: right;"
+                                                             process="@form"
+                                                             update="msgs confirmDialogPanel"
+                                                             oncomplete="if (args &amp;&amp; !args.validationFailed) PF('confirmDialog').show();" />
                                         </h2>
                                     </f:facet>
 
@@ -91,10 +93,13 @@
                                     </h:panelGroup>
 
                                     <p:outputLabel for="txtQty" value="Requesting Diesel Quantity in Liters" />
-                                    <p:inputText id="txtQty"
-                                                 required="true" 
-                                                 class="w-100"
-                                                 requiredMessage="Quantity is required" 
+                                    <p:inputNumber id="txtQty"
+                                                 minValue="0"
+                                                 decimalPlaces="2"
+                                                 required="true"
+                                                 styleClass="w-100"
+                                                 inputStyleClass="w-100"
+                                                 requiredMessage="Quantity is required"
                                                  value="#{fuelRequestAndIssueController.selected.requestQuantity}" />
 
                                     <p:outputLabel for="txtOdo" value="Vehicle ODO Meter Reading / Generator Hours" />
@@ -121,6 +126,70 @@
                                         value="#{fuelRequestAndIssueController.selected.comments}" />
                                 </p:panelGrid>
 
+                                <!-- Confirmation dialog: shown after client-side validation passes -->
+                                <p:dialog header="Confirm Fuel Request"
+                                          widgetVar="confirmDialog"
+                                          modal="true"
+                                          closable="true"
+                                          responsive="true">
+                                    <h:panelGroup id="confirmDialogPanel" layout="block">
+                                        <div class="p-3">
+                                            <h5>Please confirm the following details:</h5>
+                                            <div class="row mb-2">
+                                                <div class="col-6 font-weight-bold">Date:</div>
+                                                <div class="col-6">
+                                                    <h:outputText value="#{fuelRequestAndIssueController.selected.requestedDate}">
+                                                        <f:convertDateTime pattern="dd MMM yyyy" />
+                                                    </h:outputText>
+                                                </div>
+                                            </div>
+                                            <div class="row mb-2">
+                                                <div class="col-6 font-weight-bold">Vehicle:</div>
+                                                <div class="col-6"><h:outputText value="#{fuelRequestAndIssueController.selected.vehicle.vehicleNumber}" /></div>
+                                            </div>
+                                            <div class="row mb-2">
+                                                <div class="col-6 font-weight-bold">Driver:</div>
+                                                <div class="col-6"><h:outputText value="#{fuelRequestAndIssueController.selected.driver.name}" /></div>
+                                            </div>
+                                            <div class="row mb-2">
+                                                <div class="col-6 font-weight-bold">Depot / Fuel Station:</div>
+                                                <div class="col-6"><h:outputText value="#{fuelRequestAndIssueController.selected.toInstitution.name}" /></div>
+                                            </div>
+                                            <div class="row mb-2">
+                                                <div class="col-6 font-weight-bold">Requesting Diesel Quantity (Liters):</div>
+                                                <div class="col-6">
+                                                    <h:outputText value="#{fuelRequestAndIssueController.selected.requestQuantity}">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputText>
+                                                </div>
+                                            </div>
+                                            <div class="row mb-2">
+                                                <div class="col-6 font-weight-bold">ODO Meter Reading / Generator Hours:</div>
+                                                <div class="col-6"><h:outputText value="#{fuelRequestAndIssueController.selected.odoMeterReading}" /></div>
+                                            </div>
+                                            <div class="row mb-2">
+                                                <div class="col-6 font-weight-bold">Request Reference Number:</div>
+                                                <div class="col-6"><h:outputText value="#{fuelRequestAndIssueController.selected.requestReferenceNumber}" /></div>
+                                            </div>
+                                            <div class="row mb-2">
+                                                <div class="col-6 font-weight-bold">Comments:</div>
+                                                <div class="col-6"><h:outputText value="#{fuelRequestAndIssueController.selected.comments}" /></div>
+                                            </div>
+                                        </div>
+                                        <div class="text-center mt-3 mb-3">
+                                            <p:commandButton value="Confirm and Submit"
+                                                             icon="pi pi-check"
+                                                             styleClass="ui-button-raised ui-button-success mx-1"
+                                                             action="#{fuelRequestAndIssueController.submitVehicleFuelRequest()}"
+                                                             ajax="false" />
+                                            <p:commandButton value="Cancel"
+                                                             icon="pi pi-times"
+                                                             type="button"
+                                                             styleClass="ui-button-raised ui-button-secondary mx-1"
+                                                             onclick="PF('confirmDialog').hide();" />
+                                        </div>
+                                    </h:panelGroup>
+                                </p:dialog>
 
                             </div>
                         </div>


### PR DESCRIPTION
Ports the fuel-order validations from the development line onto the production line (`production-dev`). Because production has a separate git history, this is a manual port adapted to production's entity model — not a cherry-pick.

## Validations added (controller)
Applied to `submitVehicleFuelRequest` **and** `submitSpecialVehicleFuelRequest`:
1. **Duplicate reference number** — blocked if the reference number was already used by the institution **in the same calendar month**, counting **active and inactive** (retired/cancelled/rejected) orders.
2. **Distinct numbers** — Reference Number, ODO Reading and Request Quantity must all be different.
3. **Required** — Reference Number, ODO Reading and Request Quantity are required.
4. **ODO increasing** — ODO reading must be greater than the vehicle's previous reading.
5. **One pending request per vehicle** — blocked if the vehicle already has a request not yet **issued**.
6. **Max quantity per vehicle type** — limits on the `VehicleType` enum (Ambulance 95, Cab 80, Car 50, Jeep 110, Van 70, Bus 350, Lorry 300, Gully Bowser 100, Tractor 60, Three Wheeler 8, Generator 100, Fogging Machine 40, Incinerator 500; Bowser 100; Service Station = no limit).

## UI (`requests/request.xhtml`)
- Quantity uses `p:inputNumber` restricted to **2 decimal places**.
- Submit now opens a **confirmation dialog** showing the entered details, with **Confirm and Submit** / **Cancel**.
- Clear **success message** including the reference number after submission.

## Production adaptations (vs development)
- **No `dispensed` field** in production → the "one pending request" check uses `issued = false`.
- **Reference uniqueness** is **calendar-month based across active + inactive** orders (per requirement), whereas development uses a rolling 30 days on non-retired orders only.

## Notes / not in scope
- Server-side validations apply to both the standard and special request submit methods. The **confirmation dialog + 2-decimal input** were added to the **primary** `request.xhtml` only; `special_request.xhtml` keeps its existing form (can be extended on request).
- Backend WAR build/deploy is handled separately by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)