### PR TITLE
Production fixes: web user role, request reference column, pay-list sort

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
@@ -1293,6 +1293,12 @@ public class FuelRequestAndIssueController implements Serializable {
                         null, // txTypes
                         null // type
                 );
+        // Sort by issued date (most recently issued first), not by the ordered/requested date.
+        // Not-yet-issued requests (null issued date) are listed last.
+        if (transactions != null) {
+            transactions.sort(Comparator.comparing(FuelTransaction::getIssuedDate,
+                    Comparator.nullsLast(Comparator.reverseOrder())));
+        }
     }
 
     public void listInstitutionRequestsPaid() {

--- a/src/main/java/lk/gov/health/phsp/enums/WebUserRole.java
+++ b/src/main/java/lk/gov/health/phsp/enums/WebUserRole.java
@@ -29,6 +29,7 @@ public enum WebUserRole {
     CPC_ADMINISTRATOR("CPC Administrator", AccessLevel.NATIONAL),
     CPC_SUPER_USER("CPC Super User", AccessLevel.NATIONAL),
     CPC_USER("CPC User", AccessLevel.INSTITUTIONAL),
+    CPC_FUEL_DISPENSOR("CPC Fuel Dispensor", AccessLevel.INSTITUTIONAL),
 
     // CB Level
     CB_ADMINISTRATOR("CB Administrator", AccessLevel.NATIONAL),

--- a/src/main/webapp/requests/list_to_mark.xhtml
+++ b/src/main/webapp/requests/list_to_mark.xhtml
@@ -76,8 +76,8 @@
                                                 <h:outputText value="#{transaction.requestQuantity}" />
                                             </p:column>
 
-                                            <p:column headerText="Referance" sortBy="#{transaction.issueReferenceNumber}" filterBy="#{transaction.issueReferenceNumber}">
-                                                <h:outputText value="#{transaction.issueReferenceNumber}">
+                                            <p:column headerText="Referance" sortBy="#{transaction.requestReferenceNumber}" filterBy="#{transaction.requestReferenceNumber}">
+                                                <h:outputText value="#{transaction.requestReferenceNumber}">
                                                 </h:outputText>
                                             </p:column>
 


### PR DESCRIPTION
Three small production-dev fixes, ported from the development line.

## 1. Add missing `CPC_FUEL_DISPENSOR` web user role (login crash)
Login failed for users whose stored `WEBUSER.WEBUSERROLE` is `CPC_FUEL_DISPENSOR`:

```
EclipseLink-116: No conversion value provided for the value [CPC_FUEL_DISPENSOR] in field [WEBUSER.WEBUSERROLE]
```

`WebUser.webUserRole` is `@Enumerated(EnumType.STRING)`, so a role name in the DB but absent from the enum can't be mapped and the login bean throws. Added the constant.
- It was the **only** role missing in production-dev; `Privilege` and `FuelTransactionType` already match.

## 2. Show request reference number on `/requests/list_to_mark`
The 4th "Referance" column was bound to `issueReferenceNumber` (empty at the request-to-mark stage). Re-bound it (and its sort/filter) to `requestReferenceNumber` — the number entered when the fuel order is placed.

## 3. Sort `/requests/list_to_pay` by issued date, not ordered date
The pay list was shown in insertion/requested order (the shared `findFuelTransactions` query has no `ORDER BY`). `listInstitutionRequestsToPay()` now sorts by **issued date descending** (most recently issued first), with not-yet-issued requests last. Page-specific — the shared query is untouched. Mirrors the dev line, which orders the pay list by the terminal date rather than the request date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)