### PR TITLE
Add City field to institution create/edit forms

### DIFF
--- a/src/main/webapp/cpc/admin/institution.xhtml
+++ b/src/main/webapp/cpc/admin/institution.xhtml
@@ -98,6 +98,9 @@
                         <h:outputLabel value="Address:" for="address" />
                         <p:inputText id="address" class="form-control"  value="#{institutionController.selected.address}" title="Address" />
 
+                        <h:outputLabel value="City:" for="cityName" />
+                        <p:inputText id="cityName" class="form-control" required="true" requiredMessage="Please enter the city" value="#{institutionController.selected.cityName}" title="City" />
+
                         <h:outputLabel value="Email:" for="email" />
                         <p:inputText id="email" class="form-control" value="#{institutionController.selected.email}" title="Email" />
 

--- a/src/main/webapp/cpc/institution.xhtml
+++ b/src/main/webapp/cpc/institution.xhtml
@@ -67,7 +67,10 @@
                                 <h:panelGrid columns="2">
                                     <h:outputLabel value="Address:" for="address" />
                                     <h:inputText id="address" class="form-control"  value="#{institutionController.selected.address}" title="Address" />
-                                    
+
+                                    <h:outputLabel value="City:" for="cityName" />
+                                    <h:inputText id="cityName" class="form-control" required="true" requiredMessage="Please enter the city" value="#{institutionController.selected.cityName}" title="City" />
+
                                     <h:outputLabel value="Fax:" for="fax" />
                                     <h:inputText id="fax" class="form-control" value="#{institutionController.selected.fax}" title="Fax" />
                                     

--- a/src/main/webapp/dataentry/institution.xhtml
+++ b/src/main/webapp/dataentry/institution.xhtml
@@ -72,6 +72,9 @@
                                     <h:outputLabel value="Address:" for="address" />
                                     <h:inputText id="address" class="form-control"  value="#{institutionController.selected.address}" title="Address" />
 
+                                    <h:outputLabel value="City:" for="cityName" />
+                                    <h:inputText id="cityName" class="form-control" required="true" requiredMessage="Please enter the city" value="#{institutionController.selected.cityName}" title="City" />
+
                                     <h:outputLabel value="Fax:" for="fax" />
                                     <h:inputText id="fax" class="form-control" value="#{institutionController.selected.fax}" title="Fax" />
 

--- a/src/main/webapp/institution/admin/institution.xhtml
+++ b/src/main/webapp/institution/admin/institution.xhtml
@@ -98,6 +98,9 @@
                         <h:outputLabel value="Address:" for="address" />
                         <p:inputText id="address" class="form-control"  value="#{institutionController.selected.address}" title="Address" />
 
+                        <h:outputLabel value="City:" for="cityName" />
+                        <p:inputText id="cityName" class="form-control" required="true" requiredMessage="Please enter the city" value="#{institutionController.selected.cityName}" title="City" />
+
                         <h:outputLabel value="Email:" for="email" />
                         <p:inputText id="email" class="form-control" value="#{institutionController.selected.email}" title="Email" />
 

--- a/src/main/webapp/institution/institution.xhtml
+++ b/src/main/webapp/institution/institution.xhtml
@@ -67,7 +67,10 @@
                                 <h:panelGrid columns="2">
                                     <h:outputLabel value="Address:" for="address" />
                                     <h:inputText id="address" class="form-control"  value="#{institutionController.selected.address}" title="Address" />
-                                    
+
+                                    <h:outputLabel value="City:" for="cityName" />
+                                    <h:inputText id="cityName" class="form-control" required="true" requiredMessage="Please enter the city" value="#{institutionController.selected.cityName}" title="City" />
+
                                     <h:outputLabel value="Fax:" for="fax" />
                                     <h:inputText id="fax" class="form-control" value="#{institutionController.selected.fax}" title="Fax" />
                                     

--- a/src/main/webapp/national/admin/institution.xhtml
+++ b/src/main/webapp/national/admin/institution.xhtml
@@ -92,6 +92,9 @@
                                     <h:outputLabel value="Address:" for="address" />
                                     <h:inputText id="address" class="form-control"  value="#{institutionController.selected.address}" title="Address" />
 
+                                    <h:outputLabel value="City:" for="cityName" />
+                                    <h:inputText id="cityName" class="form-control" required="true" requiredMessage="Please enter the city" value="#{institutionController.selected.cityName}" title="City" />
+
                                     <h:outputLabel value="Fax:" for="fax" />
                                     <h:inputText id="fax" class="form-control" value="#{institutionController.selected.fax}" title="Fax" />
 

--- a/src/main/webapp/vehicle/admin/institution.xhtml
+++ b/src/main/webapp/vehicle/admin/institution.xhtml
@@ -66,7 +66,10 @@
                                 <h:panelGrid columns="2">
                                     <h:outputLabel value="Address:" for="address" />
                                     <h:inputText id="address" class="form-control"  value="#{institutionController.selected.address}" title="Address" />
-                                    
+
+                                    <h:outputLabel value="City:" for="cityName" />
+                                    <h:inputText id="cityName" class="form-control" required="true" requiredMessage="Please enter the city" value="#{institutionController.selected.cityName}" title="City" />
+
                                     <h:outputLabel value="Fax:" for="fax" />
                                     <h:inputText id="fax" class="form-control" value="#{institutionController.selected.fax}" title="Fax" />
                                     


### PR DESCRIPTION
## Summary
- `Institution.cityName` is a `NOT NULL` column (`Institution.java:91`), but no institution create/edit form had an input bound to it.
- Every save of a new institution failed with `SQLIntegrityConstraintViolationException: Column 'CITYNAME' cannot be null` (96 occurrences in the fmis-test Payara log since 2026-07-10).
- Added a required "City" input right after "Address" in the 7 affected institution create/edit forms: `dataentry/institution.xhtml`, `cpc/institution.xhtml`, `institution/institution.xhtml`, `national/admin/institution.xhtml`, `vehicle/admin/institution.xhtml`, `cpc/admin/institution.xhtml`, `institution/admin/institution.xhtml`.
- Verified no existing `INSTITUTION` rows have a `NULL` city name, so no data backfill was needed.

## Test plan
- [x] Built the WAR and redeployed to the `fmis-test` Payara domain; app started cleanly with no errors.
- [ ] Create a new institution via each of the 7 forms and confirm save succeeds with the City field populated.
- [ ] Confirm validation message appears when City is left blank.