### PR TITLE
Fix Reports link forcing HTTPS navigation for fuel-receiver institutions

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/ReportController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/ReportController.java
@@ -315,7 +315,7 @@ public class ReportController implements Serializable {
             case CPC_HEAD_OFFICE:
                 return "/reports/cpc_head_office/index";
             case FUEL_RECEIVER:
-                return "/reports/index?faces-redirect=true;";
+                return "/reports/index";
             case MONITORING_AND_EVALUATION:
             case OTHER:
                 return "/institution/reports/index";


### PR DESCRIPTION
## Summary
- Clicking the "Reports" nav link for institutions in the `FUEL_RECEIVER` category triggered a client-side `faces-redirect`, causing a fresh browser navigation whose URL scheme resolved to `https://` — this breaks on servers/dev setups that only serve plain HTTP (e.g. `http://localhost:8080`), showing a connection error instead of the Reports page.
- Every other institution category in `ReportController.navigateToReportsIndex()` returns a plain forward outcome (no `faces-redirect`), so the browser URL/scheme never changes. This PR makes the `FUEL_RECEIVER` case consistent with the rest.

## Test plan
- [ ] Log in as a user belonging to a `FUEL_RECEIVER`-category institution and click "Reports" — confirm it loads `/reports/index.xhtml` without a scheme/protocol change or connection error.
- [ ] Spot-check other categories (CPC, CPC_HEAD_OFFICE, MONITORING_AND_EVALUATION/OTHER) still navigate to their respective Reports pages correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)