### PR TITLE
Require name/phone/NIC on user & driver forms; surface form messages near header

### DIFF
--- a/src/main/webapp/cpc/admin/user_new.xhtml
+++ b/src/main/webapp/cpc/admin/user_new.xhtml
@@ -14,6 +14,7 @@
                             <p:outputLabel value="Add New User" ></p:outputLabel>
 
                         </div>
+                        <p:messages></p:messages>
                         <div class="card-body bg-white">
                             <div class="form-group row mb-2">
                                 <label class="col-md-4 fs-6 fw-bold col-form-label" for="Name">
@@ -81,9 +82,9 @@
                                 </div>
                             </div>
                             <div class="form-group row mb-2">
-                                <label class="col-md-4 fs-6 fw-bold col-form-label" for="telNo">Telephone Number</label>
+                                <label class="col-md-4 fs-6 fw-bold col-form-label" for="telNo">User's Phone Number (not the institution's)<small>(Required)</small></label>
                                 <div class="col-md-8">
-                                    <p:inputText id="telNo" class="form-control w-100" value="#{webUserController.selected.telNo}" autocomplete="false" title="#{bundleClinical.EditWebUserTitle_telNo}" />
+                                    <p:inputText id="telNo" class="form-control w-100" value="#{webUserController.selected.telNo}" autocomplete="false" title="#{bundleClinical.EditWebUserTitle_telNo}" required="true" requiredMessage="The user's phone number is required." />
                                 </div>
                             </div>
                             <div class="form-group row mb-2">
@@ -110,8 +111,7 @@
                                 value="#{bundleClinical.Save}" /> 
                         </div>
                     </div>
-                    <p:messages></p:messages>
-                </h:form>   
+                </h:form>
             </ui:define>
         </ui:composition>
     </h:body>

--- a/src/main/webapp/dataentry/driver.xhtml
+++ b/src/main/webapp/dataentry/driver.xhtml
@@ -33,27 +33,30 @@
 
 
 
-                            <h:outputLabel value="Name:" for="name" />
-                            <h:inputText id="name" 
+                            <h:outputLabel value="Name: *" for="name" />
+                            <h:inputText id="name"
                                          autocomplete="off"
                                          class="form-control"
-                                         value="#{driverController.selected.name}" title="Name" />
+                                         value="#{driverController.selected.name}" title="Name"
+                                         required="true" requiredMessage="Driver's name is required." />
 
 
-                            <h:outputLabel value="NIC:" for="nic" />
-                            <h:inputText id="nic" 
+                            <h:outputLabel value="NIC: *" for="nic" />
+                            <h:inputText id="nic"
                                          autocomplete="off"
                                          class="form-control"
-                                         value="#{driverController.selected.nic}" 
-                                         title="NIC" />
+                                         value="#{driverController.selected.nic}"
+                                         title="NIC"
+                                         required="true" requiredMessage="Driver's NIC is required." />
 
 
-                            <h:outputLabel value="Phone:" for="phone" />
-                            <h:inputText id="phone" 
+                            <h:outputLabel value="Phone: *" for="phone" />
+                            <h:inputText id="phone"
                                          autocomplete="off"
                                          class="form-control"
-                                         value="#{driverController.selected.phone}" 
-                                         title="phone" />
+                                         value="#{driverController.selected.phone}"
+                                         title="phone"
+                                         required="true" requiredMessage="Driver's phone number is required." />
 
 
                             <h:outputLabel value="Address:" for="address" />

--- a/src/main/webapp/dataentry/user_new.xhtml
+++ b/src/main/webapp/dataentry/user_new.xhtml
@@ -12,6 +12,7 @@
                 <h:form >
                     <div class="div bg-white px-4 py-3">
                         <h3 class="fw-bold mb-3">Add New User</h3>
+                        <p:messages></p:messages>
                         <div class="row mb-3">
                             <label for="name" class="col-md-4 col-form-label fw-bold">
                                 Name : <small>(Required)</small>
@@ -75,9 +76,9 @@
                             </div>
                         </div>
                         <div class="row mb-3">
-                            <label for="telNo" class="col-form-label fw-bold col-md-4">Telephone Number :</label>
+                            <label for="telNo" class="col-form-label fw-bold col-md-4">User's Phone Number (not the institution's) : <small>(Required)</small></label>
                             <div class="col-md-8">
-                                <h:inputText id="telNo" autocomplete="false" class="form-control" value="#{webUserController.selected.telNo}" title="#{bundleClinical.EditWebUserTitle_telNo}" />
+                                <h:inputText id="telNo" autocomplete="false" class="form-control" value="#{webUserController.selected.telNo}" title="#{bundleClinical.EditWebUserTitle_telNo}" required="true" requiredMessage="The user's phone number is required." />
                             </div>
                         </div>
                         <div class="row mb-3">
@@ -103,9 +104,6 @@
                                 </p:selectOneMenu>
                                 <h:message class="text-danger small" for="webUserRole"></h:message>
                             </div>
-                        </div>
-                        <div class="row mb-3">
-                            <p:messages></p:messages>
                         </div>
                         <div class="buttons">
                             <h:commandButton class="btn btn-success fw-bold" 

--- a/src/main/webapp/insAdmin/user_new.xhtml
+++ b/src/main/webapp/insAdmin/user_new.xhtml
@@ -14,6 +14,7 @@
                             <div class="card-header bg-success text-white">
                                 <p:outputLabel class="fs-5 fw-bold my-2" value="Add New User" ></p:outputLabel>
                             </div>
+                            <h:messages class="alert alert-danger ps-5"></h:messages>
                             <div class="card-body my-2">
                                 <div class="row">
                                     <div class="col-md-6">
@@ -71,9 +72,9 @@
                                             </div>
                                         </div>
                                         <div class="form-group row">
-                                            <h:outputLabel class="fs-6 fw-bold col-md-4" value="Telephone Number.:" for="telNo" />
+                                            <h:outputLabel class="fs-6 fw-bold col-md-4" value="User's Phone Number (not the institution's):" for="telNo" />
                                             <div class="col-md-8 mb-4">
-                                                <h:inputText id="telNo" class="form-control" value="#{webUserController.selected.telNo}" autocomplete="false" title="#{bundleClinical.EditWebUserTitle_telNo}" />
+                                                <h:inputText id="telNo" class="form-control" value="#{webUserController.selected.telNo}" autocomplete="false" title="#{bundleClinical.EditWebUserTitle_telNo}" required="true" requiredMessage="The user's phone number is required." />
                                             </div>
                                         </div>
                                         <div class="form-group row">
@@ -92,12 +93,6 @@
                                     </div>
                                     <div class="col-md-1"></div>
                                     <div class="col-md-5">
-                                        <!-- Display any error message when Save -->
-                                        <div class="row">
-                                            <div class="col-lg-12">
-                                                <h:messages class="alert alert-danger ps-5"></h:messages>
-                                            </div>
-                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/src/main/webapp/institution/admin/driver.xhtml
+++ b/src/main/webapp/institution/admin/driver.xhtml
@@ -48,27 +48,30 @@
 
 
 
-                            <h:outputLabel value="Name:" for="name" />
-                            <h:inputText id="name" 
+                            <h:outputLabel value="Name: *" for="name" />
+                            <h:inputText id="name"
                                          autocomplete="off"
                                          class="form-control"
-                                         value="#{driverController.selected.name}" title="Name" />
+                                         value="#{driverController.selected.name}" title="Name"
+                                         required="true" requiredMessage="Driver's name is required." />
 
 
-                            <h:outputLabel value="NIC:" for="nic" />
-                            <h:inputText id="nic" 
+                            <h:outputLabel value="NIC: *" for="nic" />
+                            <h:inputText id="nic"
                                          autocomplete="off"
                                          class="form-control"
-                                         value="#{driverController.selected.nic}" 
-                                         title="NIC" />
+                                         value="#{driverController.selected.nic}"
+                                         title="NIC"
+                                         required="true" requiredMessage="Driver's NIC is required." />
 
 
-                            <h:outputLabel value="Phone:" for="phone" />
-                            <h:inputText id="phone" 
+                            <h:outputLabel value="Phone: *" for="phone" />
+                            <h:inputText id="phone"
                                          autocomplete="off"
                                          class="form-control"
-                                         value="#{driverController.selected.phone}" 
-                                         title="phone" />
+                                         value="#{driverController.selected.phone}"
+                                         title="phone"
+                                         required="true" requiredMessage="Driver's phone number is required." />
 
 
                             <h:outputLabel value="Address:" for="address" />

--- a/src/main/webapp/institution/admin/user_new.xhtml
+++ b/src/main/webapp/institution/admin/user_new.xhtml
@@ -14,6 +14,7 @@
                             <p:outputLabel value="Add New User" ></p:outputLabel>
 
                         </div>
+                        <p:messages></p:messages>
                         <div class="card-body bg-white">
                             <div class="form-group row mb-2">
                                 <label class="col-md-4 fs-6 fw-bold col-form-label" for="Name">
@@ -81,9 +82,9 @@
                                 </div>
                             </div>
                             <div class="form-group row mb-2">
-                                <label class="col-md-4 fs-6 fw-bold col-form-label" for="telNo">Telephone Number</label>
+                                <label class="col-md-4 fs-6 fw-bold col-form-label" for="telNo">User's Phone Number (not the institution's)<small>(Required)</small></label>
                                 <div class="col-md-8">
-                                    <p:inputText id="telNo" class="form-control w-100" value="#{webUserController.selected.telNo}" autocomplete="false" title="#{bundleClinical.EditWebUserTitle_telNo}" />
+                                    <p:inputText id="telNo" class="form-control w-100" value="#{webUserController.selected.telNo}" autocomplete="false" title="#{bundleClinical.EditWebUserTitle_telNo}" required="true" requiredMessage="The user's phone number is required." />
                                 </div>
                             </div>
                             <div class="form-group row mb-2">
@@ -110,8 +111,7 @@
                                 value="#{bundleClinical.Save}" /> 
                         </div>
                     </div>
-                    <p:messages></p:messages>
-                </h:form>   
+                </h:form>
             </ui:define>
         </ui:composition>
     </h:body>

--- a/src/main/webapp/national/admin/driver.xhtml
+++ b/src/main/webapp/national/admin/driver.xhtml
@@ -33,27 +33,30 @@
 
 
 
-                            <h:outputLabel value="Name:" for="name" />
-                            <h:inputText id="name" 
+                            <h:outputLabel value="Name: *" for="name" />
+                            <h:inputText id="name"
                                          autocomplete="off"
                                          class="form-control"
-                                         value="#{driverController.selected.name}" title="Name" />
+                                         value="#{driverController.selected.name}" title="Name"
+                                         required="true" requiredMessage="Driver's name is required." />
 
 
-                            <h:outputLabel value="NIC:" for="nic" />
-                            <h:inputText id="nic" 
+                            <h:outputLabel value="NIC: *" for="nic" />
+                            <h:inputText id="nic"
                                          autocomplete="off"
                                          class="form-control"
-                                         value="#{driverController.selected.nic}" 
-                                         title="NIC" />
+                                         value="#{driverController.selected.nic}"
+                                         title="NIC"
+                                         required="true" requiredMessage="Driver's NIC is required." />
 
 
-                            <h:outputLabel value="Phone:" for="phone" />
-                            <h:inputText id="phone" 
+                            <h:outputLabel value="Phone: *" for="phone" />
+                            <h:inputText id="phone"
                                          autocomplete="off"
                                          class="form-control"
-                                         value="#{driverController.selected.phone}" 
-                                         title="phone" />
+                                         value="#{driverController.selected.phone}"
+                                         title="phone"
+                                         required="true" requiredMessage="Driver's phone number is required." />
 
 
                             <h:outputLabel value="Address:" for="address" />

--- a/src/main/webapp/national/admin/user_new.xhtml
+++ b/src/main/webapp/national/admin/user_new.xhtml
@@ -12,6 +12,7 @@
                 <h:form >
                     <div class="div bg-white px-4 py-3">
                         <h3 class="fw-bold mb-3">Add New User</h3>
+                        <p:messages></p:messages>
                         <div class="row mb-3">
                             <label for="name" class="col-md-4 col-form-label fw-bold">
                                 Name : <small>(Required)</small>
@@ -73,9 +74,10 @@
                             </div>
                         </div>
                         <div class="row mb-3">
-                            <label for="telNo" class="col-form-label fw-bold col-md-4">Telephone Number :</label>
+                            <label for="telNo" class="col-form-label fw-bold col-md-4">User's Phone Number (not the institution's) : <small>(Required)</small></label>
                             <div class="col-md-8">
-                                <h:inputText id="telNo" autocomplete="false" class="form-control" value="#{webUserController.selected.telNo}" title="#{bundleClinical.EditWebUserTitle_telNo}" />
+                                <h:inputText id="telNo" autocomplete="false" class="form-control" value="#{webUserController.selected.telNo}" title="#{bundleClinical.EditWebUserTitle_telNo}" required="true" requiredMessage="The user's phone number is required." />
+                                <h:message class="small text-danger" for="telNo"></h:message>
                             </div>
                         </div>
                         <div class="row mb-3">
@@ -101,9 +103,6 @@
                                 </p:selectOneMenu>
                                 <h:message class="text-danger small" for="webUserRole"></h:message>
                             </div>
-                        </div>
-                        <div class="row mb-3">
-                            <p:messages></p:messages>
                         </div>
                         <div class="buttons">
                             <h:commandButton class="btn btn-success fw-bold" action="#{webUserController.saveNewWebUser()}" value="Save User"/>

--- a/src/main/webapp/reports/cpc/index.xhtml
+++ b/src/main/webapp/reports/cpc/index.xhtml
@@ -18,6 +18,7 @@
                     <div class="card-header">
                         <h:outputLabel value="Reports for CPC" ></h:outputLabel>
                     </div>
+                    <p:messages></p:messages>
                     <div class="row">
                         <div class="col-md-2">
                             <h:form class="form">

--- a/src/main/webapp/reports/cpc_head_office/index.xhtml
+++ b/src/main/webapp/reports/cpc_head_office/index.xhtml
@@ -18,6 +18,7 @@
                     <div class="card-header">
                         <h:outputLabel value="Reports for CPC" ></h:outputLabel>
                     </div>
+                    <p:messages></p:messages>
                     <div class="row">
                         <div class="col-md-2">
                             <h:form class="form">

--- a/src/main/webapp/reports/index.xhtml
+++ b/src/main/webapp/reports/index.xhtml
@@ -23,6 +23,7 @@
                             <i class="fa fa-bars"></i> <span id="reportsNavToggleLabel">Collapse Panel</span>
                         </button>
                     </div>
+                    <p:messages></p:messages>
                     <div class="row">
                         <div id="reportsNavCol" class="col-md-2">
                             <h:form class="form" id="reportsNavBody">

--- a/src/main/webapp/reports/list_to_paid.xhtml
+++ b/src/main/webapp/reports/list_to_paid.xhtml
@@ -22,6 +22,7 @@
                             <div class="card-header" >
                                 <h2><h:outputText value="Search Payment Requests"></h:outputText></h2>
                             </div>
+                            <p:messages></p:messages>
                             <div class="card-body" >
 
                                 <div class="row" >

--- a/src/main/webapp/reports/requested_edit.xhtml
+++ b/src/main/webapp/reports/requested_edit.xhtml
@@ -40,6 +40,7 @@
 
 
                                     </div>
+                                    <p:messages></p:messages>
                                     <div class="card-body" >
 
 

--- a/src/main/webapp/vehicle/admin/user_new.xhtml
+++ b/src/main/webapp/vehicle/admin/user_new.xhtml
@@ -14,6 +14,7 @@
                             <p:outputLabel value="Add New User" ></p:outputLabel>
 
                         </div>
+                        <p:messages></p:messages>
                         <div class="card-body bg-white">
 
                             <div class="form-group row my-2">
@@ -117,9 +118,9 @@
                                 </div>
                             </div>
                             <div class="form-group row mb-2">
-                                <label class="col-md-4 fs-6 fw-bold col-form-label" for="telNo">Telephone Number</label>
+                                <label class="col-md-4 fs-6 fw-bold col-form-label" for="telNo">User's Phone Number (not the institution's)<small>(Required)</small></label>
                                 <div class="col-md-8">
-                                    <p:inputText id="telNo" class="form-control w-100" value="#{webUserController.selected.telNo}" autocomplete="false" title="#{bundleClinical.EditWebUserTitle_telNo}" />
+                                    <p:inputText id="telNo" class="form-control w-100" value="#{webUserController.selected.telNo}" autocomplete="false" title="#{bundleClinical.EditWebUserTitle_telNo}" required="true" requiredMessage="The user's phone number is required." />
                                 </div>
                             </div>
                             <div class="form-group row mb-2">
@@ -144,8 +145,7 @@
                                              value="#{bundleClinical.Save}" /> 
                         </div>
                     </div>
-                    <p:messages></p:messages>
-                </h:form>   
+                </h:form>
             </ui:define>
         </ui:composition>
     </h:body>


### PR DESCRIPTION
## Summary
- Made the phone number mandatory on all six "Add New User" pages (`national/admin`, `insAdmin`, `cpc/admin`, `institution/admin`, `vehicle/admin`, `dataentry`) and relabeled it to make clear it's the **user's own** phone number, not the institution's.
- Made name, phone, and NIC mandatory on the three editable driver add/edit forms (`national/admin/driver.xhtml`, `dataentry/driver.xhtml`, `institution/admin/driver.xhtml`). The read-only `cpc/admin/driver.xhtml` view page was left unchanged.
- Moved validation/error messages from the bottom of these forms to right below each page's own header, since users weren't scrolling far enough to notice them.
- Applied the same message-placement fix to report pages that had no `p:messages` of their own and were silently relying on the site-wide message placeholder at the very bottom of `template.xhtml` (`reports/index.xhtml`, `reports/cpc/index.xhtml`, `reports/cpc_head_office/index.xhtml`, `reports/list_to_paid.xhtml`, `reports/requested_edit.xhtml`).

## Test plan
- [ ] Open each "Add New User" page and confirm the phone field is required with a clear label, and validation messages appear right under the header.
- [ ] Open each driver add page and confirm name/phone/NIC are required.
- [ ] Trigger a validation error on the Payment List and Fuel Request Details report pages and confirm the message shows near the top, not the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)