### PR TITLE
Scope transaction/payment reports to own institution for institution-level users

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
@@ -1095,6 +1095,26 @@ public class FuelRequestAndIssueController implements Serializable {
         bills = tmpBills;
     }
 
+    public void listPaymentBillsForInstitutionLevel() {
+        String j = "SELECT b "
+                + " FROM Bill b "
+                + " WHERE b.retired = false "
+                + " AND b.fromInstitution IN :institutions "
+                + " AND b.billDate BETWEEN :fromDate AND :toDate";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("institutions", webUserController.findAutherizedInstitutions());
+        if (fuelStation != null) {
+            j += " AND b.toInstitution=:fs ";
+            params.put("fs", fuelStation);
+        }
+        params.put("fromDate", fromDate); // fromDate should be set beforehand
+        params.put("toDate", toDate);     // toDate should be set beforehand
+
+        List<Bill> tmpBills = billFacade.findByJpql(j, params);
+        bills = tmpBills;
+    }
+
     public void listPaymentBillsForNationalLevel() {
         String j = "SELECT b "
                 + " FROM Bill b "

--- a/src/main/java/lk/gov/health/phsp/bean/ReportController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/ReportController.java
@@ -172,11 +172,18 @@ public class ReportController implements Serializable {
     // </editor-fold> 
     // <editor-fold defaultstate="collapsed" desc="Navigational Methods">
     public String navigateToListFuelRequests() {
+        if (webUserController.isInstitutionLevelUser()) {
+            fillInstitutionFuelTransactions();
+            return "/reports/list_institution?faces-redirect=true;";
+        }
         fillAllInstitutionFuelTransactions();
         return "/reports/list?faces-redirect=true;";
     }
-    
+
     public String navigateToListPayments() {
+        if (webUserController.isInstitutionLevelUser()) {
+            return "/reports/list_to_paid_institution?faces-redirect=true;";
+        }
         return "/reports/list_to_paid?faces-redirect=true;";
     }
 
@@ -489,6 +496,20 @@ public class ReportController implements Serializable {
     // <editor-fold defaultstate="collapsed" desc="Functional Methods">
     public void fillAllInstitutionFuelTransactions() {
         transactionLights = fillFuelTransactions(fromInstitution, toInstitution, getFromDate(), getToDate(), vehicleType, vehiclePurpose, driver, institutionType);
+    }
+
+    /**
+     * Restricts the transaction list to the logged user's own institution and its child institutions,
+     * for institution-level users (institution user/super user/administrator/transport/accounts).
+     */
+    public void fillInstitutionFuelTransactions() {
+        List<Institution> allowedInstitutions = webUserController.findAutherizedInstitutions();
+        if (allowedInstitutions == null || allowedInstitutions.isEmpty()) {
+            transactionLights = new ArrayList<>();
+            return;
+        }
+        List<Institution> fuelStations = toInstitution != null ? Arrays.asList(toInstitution) : null;
+        transactionLights = fillFuelTransactions(allowedInstitutions, fuelStations, getFromDate(), getToDate(), vehicleType, vehiclePurpose, driver, institutionType);
     }
 
     public void fillAllInstitutionFuelTransactionsDetailes() {
@@ -934,8 +955,11 @@ public class ReportController implements Serializable {
                 .append("ft.issueReferenceNumber, ")
                 .append("fi.name, ") // fromInstitution name
                 .append("ti.name, ") // toInstitution name
-                .append("COALESCE(d.name, 'No Driver')") // driver name or 'No Driver' if null
-                .append(") FROM FuelTransaction ft ")
+                .append("COALESCE(d.name, 'No Driver'), ") // driver name or 'No Driver' if null
+                .append("ti.code, ") // toInstitution code
+                .append("ft.issuedDate, ")
+                .append("ft.submittedToPayment, ")
+                .append("ft.submittedToPaymentAt) FROM FuelTransaction ft ")
                 .append("LEFT JOIN ft.vehicle v ")
                 .append("LEFT JOIN ft.driver d ")
                 .append("LEFT JOIN ft.fromInstitution fi ")

--- a/src/main/java/lk/gov/health/phsp/bean/WebUserController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/WebUserController.java
@@ -215,6 +215,20 @@ public class WebUserController implements Serializable {
         }
         return true;
     }
+
+    /**
+     * True for institution-level users (institution user/super user/administrator/transport/accounts)
+     * whose visibility should be restricted to their own institution and its child institutions.
+     */
+    public boolean isInstitutionLevelUser() {
+        if (loggedUser == null) {
+            return false;
+        }
+        if (loggedUser.getWebUserRoleLevel() == null) {
+            return false;
+        }
+        return loggedUser.getWebUserRoleLevel() == WebUserRoleLevel.FUEL_REQUESTING_INSTITUTION;
+    }
     
     public boolean isDieselFuelRequestMenuAvailable() {
         if (loggedUser == null) {

--- a/src/main/webapp/reports/list_institution.xhtml
+++ b/src/main/webapp/reports/list_institution.xhtml
@@ -1,0 +1,170 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+
+        <ui:composition template="./index.xhtml">
+
+            <ui:define name="reports">
+                <h:form >
+                    <p:panelGrid columns="3" >
+                        <p:panelGrid columns="2" >
+                            <p:outputLabel value="From" >
+                            </p:outputLabel>
+                            <p:calendar value="#{reportController.fromDate}"
+                                        pattern="dd MMMM yyyy">
+                            </p:calendar>
+
+                            <p:outputLabel value="To" >
+                            </p:outputLabel>
+                            <p:calendar value="#{reportController.toDate}"
+                                        pattern="dd MMMM yyyy">
+                            </p:calendar>
+                        </p:panelGrid>
+                        <p:panelGrid columns="2" >
+                            <p:outputLabel value="Requested from Fuel Station" >
+                            </p:outputLabel>
+                            <p:autoComplete
+                                value="#{reportController.toInstitution}"
+                                completeMethod="#{institutionController.completeFuelStations}"
+                                var="fs"
+                                itemLabel="#{fs.name}"
+                                itemValue="#{fs}"
+                                ></p:autoComplete>
+                        </p:panelGrid>
+                        <p:panelGrid columns="2" >
+                            <h:outputLabel value="Type:" for="vehicleType" />
+                            <p:selectOneMenu id="vehicleType"
+                                             class="form-control"
+                                             value="#{reportController.vehicleType}"
+                                             title="Vehicle Type"
+                                             filter="true"
+                                             filterMatchMode="contains">
+                                <f:selectItem itemLabel="Any" ></f:selectItem>
+                                <f:selectItems value="#{applicationController.vehicleTypes}"
+                                               var="vt"
+                                               itemValue="#{vt}"
+                                               itemLabel="#{vt.label}"/>
+                            </p:selectOneMenu>
+
+                            <h:outputLabel value="Purpose:" for="vehiclePurpose" />
+                            <p:selectOneMenu id="vehiclePurpose"
+                                             class="form-control"
+                                             value="#{reportController.vehiclePurpose}"
+                                             title="VehiclePurpose"
+                                             filter="true"
+                                             filterMatchMode="contains">
+                                <f:selectItem itemLabel="Any" ></f:selectItem>
+                                <f:selectItems value="#{applicationController.vehiclePurposes}"
+                                               var="vp"
+                                               itemValue="#{vp}"
+                                               itemLabel="#{vp.label}"/>
+                            </p:selectOneMenu>
+                        </p:panelGrid>
+
+                        <p:commandButton
+                            value="Process"
+                            ajax="false"
+                            action="#{reportController.fillInstitutionFuelTransactions()}" ></p:commandButton>
+
+
+                        <p:commandButton value="Download Excel After Process" ajax="false" icon="pi pi-download">
+                            <p:fileDownload value="#{reportController.downloadExcelFile}" />
+                        </p:commandButton>
+
+                    </p:panelGrid>
+
+                    <p:dataTable var="transaction"
+                                 id="tbl"
+                                 class="w-100"
+                                 value="#{reportController.transactionLights}"
+                                 paginator="true"
+                                 rows="10"
+                                 paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                 rowsPerPageTemplate="10,25,100,{ShowAll|'All'}"
+                                 currentPageReportTemplate="Showing {startRecord} to {endRecord} of {totalRecords} entries"
+                                 widgetVar="transactionTable">
+
+                        <p:column headerText="Date" sortBy="#{transaction.date}" filterBy="#{transaction.date}" filterMatchMode="contains">
+                            <h:outputText value="#{transaction.formattedDate}">
+                            </h:outputText>
+                        </p:column>
+
+                        <p:column headerText="Institution" sortBy="#{transaction.fromInstitutionName}" filterBy="#{transaction.fromInstitutionName}" filterMatchMode="contains">
+                            <h:outputText value="#{transaction.fromInstitutionName}" />
+                        </p:column>
+
+                        <p:column headerText="Fuel Station" sortBy="#{transaction.toInstitutionName}" filterBy="#{transaction.toInstitutionName}" filterMatchMode="contains">
+                            <h:outputText value="#{transaction.toInstitutionName}" />
+                        </p:column>
+
+                        <p:column headerText="Dealer Number" sortBy="#{transaction.toInstitutionCode}" filterBy="#{transaction.toInstitutionCode}" filterMatchMode="contains">
+                            <h:outputText value="#{transaction.toInstitutionCode}" />
+                        </p:column>
+
+                        <p:column headerText="Requested Reference No" sortBy="#{transaction.requestReferenceNumber}" filterBy="#{transaction.requestReferenceNumber}" filterMatchMode="contains">
+                            <p:commandLink
+                                ajax="false"
+                                value="#{transaction.requestReferenceNumber}"
+                                action="#{reportController.navigateToViewRequest()}">
+                                <f:setPropertyActionListener value="#{transaction}" target="#{reportController.fuelTransactionLight}" >
+                                </f:setPropertyActionListener>
+                            </p:commandLink>
+                        </p:column>
+
+                        <p:column headerText="Vehicle Number" sortBy="#{transaction.vehicleNumber}" filterBy="#{transaction.vehicleNumber}" filterMatchMode="contains">
+                            <h:outputText value="#{transaction.vehicleNumber}" />
+                        </p:column>
+
+                        <p:column headerText="Driver Name" sortBy="#{transaction.driverName}" filterBy="#{transaction.driverName}" filterMatchMode="contains">
+                            <h:outputText value="#{transaction.driverName}" />
+                        </p:column>
+
+                        <p:column headerText="Requested Qty" sortBy="#{transaction.requestQuantity}" filterBy="#{transaction.requestQuantity}" filterMatchMode="numeric">
+                            <h:outputText value="#{transaction.requestQuantity}" />
+                        </p:column>
+
+                        <p:column headerText="Issued Qty" sortBy="#{transaction.issuedQuantity}" filterBy="#{transaction.issuedQuantity}" filterMatchMode="numeric">
+                            <h:outputText value="#{transaction.issuedQuantity}" />
+                        </p:column>
+
+                        <p:column headerText="Issued Date *" sortBy="#{transaction.issuedDate}" filterBy="#{transaction.issuedDate}" filterMatchMode="numeric">
+                            <h:outputText value="#{transaction.issuedDate}" >
+                                <f:convertDateTime pattern="yyyy MMMM dd" ></f:convertDateTime>
+                            </h:outputText>
+                        </p:column>
+
+                        <p:column headerText="Issue Reference No" sortBy="#{transaction.issueReferenceNumber}" filterBy="#{transaction.issueReferenceNumber}" filterMatchMode="contains">
+                            <h:outputText value="#{transaction.issueReferenceNumber}" />
+                        </p:column>
+
+                        <p:column headerText="Payment Submission" sortBy="#{transaction.submittedForPayment}" filterBy="#{transaction.submittedForPayment}">
+                            <p:commandLink
+                                ajax="false"
+                                action="#{reportController.navigateToViewRequest()}"
+                                title="View request">
+                                <f:setPropertyActionListener value="#{transaction}" target="#{reportController.fuelTransactionLight}" >
+                                </f:setPropertyActionListener>
+                                <h:outputText value="Submitted for Payment" styleClass="badge bg-success text-wrap" rendered="#{transaction.submittedForPayment}" />
+                                <h:outputText value="Not Submitted" styleClass="badge bg-secondary text-wrap" rendered="#{!transaction.submittedForPayment}" />
+                            </p:commandLink>
+                        </p:column>
+
+                        <p:column headerText="Submitted On" sortBy="#{transaction.submittedToPaymentAt}" filterBy="#{transaction.submittedToPaymentAt}" filterMatchMode="numeric">
+                            <h:outputText value="#{transaction.formattedSubmittedToPaymentAt}" />
+                        </p:column>
+
+                    </p:dataTable>
+
+                </h:form>
+            </ui:define>
+
+        </ui:composition>
+
+    </h:body>
+</html>

--- a/src/main/webapp/reports/list_to_paid_institution.xhtml
+++ b/src/main/webapp/reports/list_to_paid_institution.xhtml
@@ -1,0 +1,161 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <body>
+
+        <ui:composition template="./../template.xhtml">
+
+            <ui:define name="title">
+                Payment List
+            </ui:define>
+
+            <ui:define name="content">
+                <div class="container-fluid p-2" >
+                    <h:form >
+
+                        <div class="card" >
+                            <div class="card-header" >
+                                <h2><h:outputText value="Search Payment Requests"></h:outputText></h2>
+                            </div>
+                            <p:messages></p:messages>
+                            <div class="card-body" >
+
+                                <div class="row" >
+                                    <div class="col-2" >
+                                        <div class="form-group">
+                                            <label for="fromDate" class="d-block">From Date</label>
+                                            <p:calendar
+                                                id="fromDate"
+                                                value="#{fuelRequestAndIssueController.fromDate}"
+                                                showButtonPanel="true"
+                                                class="w-100 m-1 d-block"
+                                                inputStyleClass="w-100"
+                                                pattern="dd MMMM yyyy"/>
+                                        </div>
+                                        <div class="form-group">
+                                            <label for="toDate" class="d-block">To Date</label>
+                                            <p:calendar
+                                                id="toDate"
+                                                value="#{fuelRequestAndIssueController.toDate}"
+                                                showButtonPanel="true"
+                                                pattern="dd MMMM yyyy"
+                                                class="w-100 m-1 d-block"
+                                                inputStyleClass="w-100" />
+                                        </div>
+                                        <div class="form-group">
+                                            <label for="reqFuelStation" class="d-block">Requested from Fuel Station</label>
+                                            <p:autoComplete
+                                                id="reqFuelStation"
+                                                value="#{fuelRequestAndIssueController.fuelStation}"
+                                                completeMethod="#{institutionController.completeFuelStations}"
+                                                var="fs"
+                                                itemLabel="#{fs.name}"
+                                                itemValue="#{fs}"
+                                                class="w-100 m-1"
+                                                inputStyleClass="w-100"></p:autoComplete>
+                                        </div>
+                                        <div class="form-group d-flex justify-content-center">
+                                            <p:commandButton value="List Requests"
+                                                             action="#{fuelRequestAndIssueController.listPaymentBillsForInstitutionLevel()}"
+                                                             icon="pi pi-list"
+                                                             ajax="false"
+                                                             class="btn btn-primary w-100 my-2" />
+
+                                        </div>
+                                        <div class="form-group d-flex justify-content-center">
+                                            <p:commandButton
+                                                value="Export to Excel"
+                                                class="btn btn-primary w-100 my-2"
+                                                ajax="false" icon="pi pi-file-excel">
+                                                <p:dataExporter type="xlsx" target="tbl" fileName="Transactions" />
+                                            </p:commandButton>
+                                        </div>
+
+                                    </div>
+                                    <div class="col-10" >
+                                        <p:dataTable
+                                            id="tbl"
+                                            value="#{fuelRequestAndIssueController.bills}" var="bill" rowKey="#{bill.id}"
+                                            rows="5"
+                                            paginator="true"
+                                            paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                            currentPageReportTemplate="{startRecord}-{endRecord} of {totalRecords} records"
+                                            rowsPerPageTemplate="5,10,20,50,{ShowAll|'All'}"
+                                            sortMode="multiple">
+
+                                            <p:column headerText="Bill Date"
+                                                      exportHeaderValue="true"
+                                                      sortBy="#{bill.billDate}" filterBy="#{bill.billDate}">
+                                                <f:facet name="header">
+                                                    <h:outputText value="Report Created Date" />
+                                                </f:facet>
+                                                <h:outputText value="#{bill.billDate}">
+                                                    <f:convertDateTime pattern="dd/MM/yyyy" />
+                                                </h:outputText>
+                                            </p:column>
+
+                                            <p:column headerText="From Institution"
+                                                      exportHeaderValue="true"
+                                                      sortBy="#{bill.fromInstitution.name}" filterBy="#{bill.fromInstitution.name}">
+                                                <f:facet name="header">
+                                                    <h:outputText value="From Institution" />
+                                                </f:facet>
+                                                <h:outputText value="#{bill.fromInstitution.name}" />
+                                            </p:column>
+
+                                            <p:column headerText="To Institution"
+                                                      exportHeaderValue="true"
+                                                      sortBy="#{bill.toInstitution.name}" filterBy="#{bill.toInstitution.name}">
+                                                <f:facet name="header">
+                                                    <h:outputText value="To Institution" />
+                                                </f:facet>
+                                                <h:outputText value="#{bill.toInstitution.name}" />
+                                            </p:column>
+
+                                            <p:column headerText="Bill Type"
+                                                      exportHeaderValue="true"
+                                                      sortBy="#{bill.billType}" filterBy="#{bill.billType}">
+                                                <f:facet name="header">
+                                                    <h:outputText value="Bill Type" />
+                                                </f:facet>
+                                                <h:outputText value="#{bill.billType}" />
+                                            </p:column>
+
+                                            <p:column headerText="Actions"
+                                                      exportHeaderValue="true">
+                                                <f:facet name="header">
+                                                    <h:outputText value="Fuel Transactions" />
+                                                </f:facet>
+
+                                                <p:commandButton
+                                                    ajax="false"
+                                                    value="View"
+                                                    action="#{fuelRequestAndIssueController.viewPaymentRequest}" >
+                                                    <f:setPropertyActionListener value="#{bill}" target="#{fuelRequestAndIssueController.fuelPaymentRequestBill}" ></f:setPropertyActionListener>
+
+                                                </p:commandButton>
+
+                                            </p:column>
+
+                                        </p:dataTable>
+
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </h:form>
+                </div>
+
+            </ui:define>
+
+
+
+        </ui:composition>
+
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- Institution users, super users, administrators, and transport/accounts staff (`WebUserRoleLevel.FUEL_REQUESTING_INSTITUTION`) previously saw transactions/payments for every institution in the system on `reports/list.xhtml` and `reports/list_to_paid.xhtml` — reachable both from the Reports index page and the "Diesel Orders" menu (View Orders / List of Payments).
- `navigateToListFuelRequests()` / `navigateToListPayments()` now route these users to new institution-scoped pages (`reports/list_institution.xhtml`, `reports/list_to_paid_institution.xhtml`) restricted to the logged-in user's own institution and its child institutions, via the existing `WebUserController.findAutherizedInstitutions()` helper. Falls back to an empty result set (not unrestricted) if no institutions resolve.
- All other roles (national/CPC/CTB/etc.) keep the existing unrestricted pages, unchanged.
- Since the Diesel Orders menu's "View Orders" and "List of Payments" items already delegate to the same two navigation methods, they get the same scoping automatically — no separate menu changes needed.

## Test plan
- [x] `mvn -o compile` succeeds
- [ ] Log in as an Institution User / Institution Super User / Institution Administrator and confirm "List of Transactions" and "List of Payments" (via Reports index and Diesel Orders menu) show only the logged institution's own + child institutions' data
- [ ] Log in as a national/CPC-level user and confirm the original unrestricted list pages still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)