### PR TITLE
Add user manual link to login page and retheme UI to Clinical Blue

### DIFF
--- a/src/main/webapp/resources/css/minty/overrides.css
+++ b/src/main/webapp/resources/css/minty/overrides.css
@@ -8,3 +8,150 @@
 html {
     font-size: 14px;
 }
+
+/*
+ * Recolors the Bootswatch "Minty" primary (teal, #78c2ad) to a "Clinical Blue"
+ * (#2c6e9c) suited to a health application, without forking the CDN-vendored
+ * bootstrap.min.css. .bg-primary/.text-primary/.link-primary already read
+ * --bs-primary-rgb, so overriding it here is enough for those; the rest of
+ * Bootstrap's primary-derived rules bake the teal in as static hex per
+ * selector, so those are restated with recomputed shades below.
+ */
+:root {
+    --bs-primary: #2c6e9c;
+    --bs-primary-rgb: 44, 110, 156;
+}
+
+a {
+    color: #2c6e9c;
+}
+a:hover {
+    color: #1f4e70;
+}
+
+.btn-primary {
+    background-color: #2c6e9c;
+    border-color: #2c6e9c;
+}
+.btn-primary:hover {
+    background-color: #255e85;
+    border-color: #23587d;
+}
+.btn-check:focus + .btn-primary,
+.btn-primary:focus {
+    background-color: #255e85;
+    border-color: #23587d;
+    box-shadow: 0 0 0 .25rem rgba(76, 132, 171, .5);
+}
+.btn-primary.disabled,
+.btn-primary:disabled {
+    background-color: #2c6e9c;
+    border-color: #2c6e9c;
+}
+
+.btn-outline-primary {
+    color: #2c6e9c;
+    border-color: #2c6e9c;
+}
+.btn-outline-primary:hover {
+    background-color: #2c6e9c;
+    border-color: #2c6e9c;
+}
+.btn-check:focus + .btn-outline-primary,
+.btn-outline-primary:focus {
+    box-shadow: 0 0 0 .25rem rgba(44, 110, 156, .5);
+}
+.btn-outline-primary.disabled,
+.btn-outline-primary:disabled {
+    color: #2c6e9c;
+}
+
+.border-primary {
+    border-color: #2c6e9c !important;
+}
+
+.form-control:focus,
+.form-select:focus,
+.form-check-input:focus {
+    border-color: #96b7ce;
+    box-shadow: 0 0 0 .25rem rgba(44, 110, 156, .25);
+}
+.form-check-input:checked {
+    background-color: #2c6e9c;
+    border-color: #2c6e9c;
+}
+
+.nav-pills .nav-link.active,
+.nav-pills .show > .nav-link {
+    background-color: #2c6e9c;
+}
+
+.page-link {
+    color: #fff;
+    background-color: #2c6e9c;
+    border-color: #2c6e9c;
+}
+.page-link:focus {
+    color: #23587d;
+    box-shadow: 0 0 0 .25rem rgba(44, 110, 156, .25);
+}
+
+.dropdown-item.active,
+.dropdown-item:active {
+    background-color: #2c6e9c;
+}
+
+.list-group-item.active {
+    background-color: #2c6e9c;
+    border-color: #2c6e9c;
+}
+
+.progress-bar {
+    background-color: #2c6e9c;
+}
+
+.alert-primary {
+    background-color: #2c6e9c;
+    border-color: #c0d4e1;
+}
+
+.table-primary {
+    --bs-table-bg: #2c6e9c;
+    --bs-table-striped-bg: #3775a1;
+    --bs-table-active-bg: #417da6;
+    --bs-table-hover-bg: #3c79a3;
+    border-color: #417da6;
+}
+
+/*
+ * The top navbar is a PrimeFaces p:menubar with Bootstrap's bg-primary/navbar-dark
+ * classes layered on top (see menu.xhtml). theme.css sets each item's text/icon
+ * color to a hardcoded #333 directly on the inner span, which wins over the
+ * inherited Bootstrap text color regardless of !important (inheritance always
+ * loses to a rule that directly matches the element). Restated here as white so
+ * top-level labels stay readable against the darker Clinical Blue background.
+ * Scoped to direct children of the menubar's own list so the white dropdown
+ * panels underneath keep their original dark-on-light text. theme.css's
+ * hover/active selectors (.ui-state-hover / .ui-menuitem-active) turn the
+ * item's own background light gray, and have the same specificity as the
+ * rules below with no source-order edge since both live in this cascade
+ * position — so hover/active text is restated dark further down to stay
+ * readable against that light-gray highlight.
+ */
+body .ui-menu.ui-menubar > .ui-menu-list > .ui-menuitem > .ui-menuitem-link .ui-menuitem-text,
+body .ui-menu.ui-menubar > .ui-menu-list > .ui-menuitem > .ui-menuitem-link .ui-menuitem-icon,
+body .ui-menu.ui-menubar > .ui-menu-list > .ui-menuitem > .ui-menuitem-link .ui-icon-triangle-1-s:last-child,
+body .ui-menu.ui-menubar > .ui-menu-list > .ui-menuitem > .ui-menuitem-link .ui-icon-triangle-1-e:last-child {
+    color: #fff;
+}
+
+body .ui-menu.ui-menubar > .ui-menu-list > .ui-menuitem > .ui-menuitem-link.ui-state-hover .ui-menuitem-text,
+body .ui-menu.ui-menubar > .ui-menu-list > .ui-menuitem > .ui-menuitem-link.ui-state-hover .ui-menuitem-icon,
+body .ui-menu.ui-menubar > .ui-menu-list > .ui-menuitem.ui-state-hover > .ui-menuitem-link .ui-menuitem-text,
+body .ui-menu.ui-menubar > .ui-menu-list > .ui-menuitem.ui-state-hover > .ui-menuitem-link .ui-menuitem-icon,
+body .ui-menu.ui-menubar > .ui-menu-list > .ui-menuitem.ui-menuitem-active > .ui-menuitem-link .ui-menuitem-text,
+body .ui-menu.ui-menubar > .ui-menu-list > .ui-menuitem.ui-menuitem-active > .ui-menuitem-link .ui-menuitem-icon,
+body .ui-menu.ui-menubar > .ui-menu-list > .ui-menuitem > .ui-menuitem-link.ui-state-hover .ui-icon-triangle-1-s:last-child,
+body .ui-menu.ui-menubar > .ui-menu-list > .ui-menuitem.ui-menuitem-active > .ui-menuitem-link .ui-icon-triangle-1-s:last-child {
+    color: #333;
+}

--- a/src/main/webapp/resources/css/minty/theme.css
+++ b/src/main/webapp/resources/css/minty/theme.css
@@ -7,7 +7,7 @@
     --surface-f: #ffffff;
     --text-color: #333333;
     --text-color-secondary: #848484;
-    --primary-color: #d90000; /* bright red */
+    --primary-color: #2c6e9c;
     --primary-color-text: #ffffff;
     --font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;
     --surface-0: #ffffff;
@@ -41,7 +41,7 @@
     --surface-border:#ecedee;
     --surface-hover:#dfe0e1;
     --maskbg: rgba(0, 0, 0, 0.4);
-    --focus-ring: 0 0 0 0.2rem #ff7f7f; /* red focus ring */
+    --focus-ring: 0 0 0 0.2rem #96b7ce;
     color-scheme:light
 }
 
@@ -201,24 +201,24 @@ body .ui-resizable-handle{
     --primary-200:#91c6ef;
     --primary-300:#61ade7;
     --primary-400:#3093e0;
-    --primary-500:#78c2ad;
+    --primary-500:#2c6e9c;
     --primary-600:#0068b8;
     --primary-700:#005598;
     --primary-800:#004377;
     --primary-900:#003157
 }
 body .ui-button{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff;
-    border:1px solid #78c2ad;
+    border:1px solid #2c6e9c;
     margin:0;
     outline:0 none;
     border-radius:3px;
     transition:background-color .2s,color .2s,border-color .2s,box-shadow .2s,opacity .2s
 }
 body .ui-button.ui-state-hover{
-    background:#7fc5b1;
-    border-color:#7fc5b1;
+    background:#1f4e70;
+    border-color:#1f4e70;
     color:#fff
 }
 body .ui-button.ui-state-focus{
@@ -227,23 +227,23 @@ body .ui-button.ui-state-focus{
     box-shadow:0 0 0 .1em rgba(0, 0, 0, 0.1)
 }
 body .ui-button.ui-state-active,body .ui-button.ui-state-down{
-    background:#86c8b5;
-    border-color:#86c8b5;
+    background:#3e8cc4;
+    border-color:#3e8cc4;
     color:#fff
 }
 body .ui-button.ui-button-outlined{
     background-color:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border:1px solid
 }
 body .ui-button.ui-button-outlined.ui-state-hover{
     background:rgba(0,122,217,.04);
-    color:#78c2ad;
+    color:#2c6e9c;
     border:1px solid
 }
 body .ui-button.ui-button-outlined.ui-state-active,body .ui-button.ui-button-outlined.ui-state-down{
     background:rgba(0,122,217,.16);
-    color:#78c2ad;
+    color:#2c6e9c;
     border:1px solid
 }
 body .ui-button.ui-button-outlined.ui-button-plain{
@@ -260,17 +260,17 @@ body .ui-button.ui-button-outlined.ui-button-plain.ui-state-active,body .ui-butt
 }
 body .ui-button.ui-button-flat{
     background-color:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-button.ui-button-flat.ui-state-hover{
     background:rgba(0,122,217,.04);
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-button.ui-button-flat.ui-state-active,body .ui-button.ui-button-flat.ui-state-down{
     background:rgba(0,122,217,.16);
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-button.ui-button-flat.ui-button-plain{
@@ -359,16 +359,16 @@ body .ui-selectbooleanbutton.ui-state-hover .ui-icon,body .ui-selectonebutton>.u
     color:#000
 }
 body .ui-selectbooleanbutton.ui-state-active,body .ui-selectonebutton>.ui-button.ui-state-active,body .ui-selectmanybutton>.ui-button.ui-state-active{
-    background:#78c2ad;
-    border-color:#78c2ad;
+    background:#2c6e9c;
+    border-color:#2c6e9c;
     color:#fff
 }
 body .ui-selectbooleanbutton.ui-state-active .ui-icon,body .ui-selectonebutton>.ui-button.ui-state-active .ui-icon,body .ui-selectmanybutton>.ui-button.ui-state-active .ui-icon{
     color:#fff
 }
 body .ui-selectbooleanbutton.ui-state-active:not(.ui-state-disabled):hover,body .ui-selectonebutton>.ui-button.ui-state-active:not(.ui-state-disabled):hover,body .ui-selectmanybutton>.ui-button.ui-state-active:not(.ui-state-disabled):hover{
-    background:#7fc5b1;
-    border-color:#7fc5b1;
+    background:#1f4e70;
+    border-color:#1f4e70;
     color:#fff
 }
 body .ui-selectbooleanbutton.ui-state-active:not(.ui-state-disabled):hover .ui-icon,body .ui-selectonebutton>.ui-button.ui-state-active:not(.ui-state-disabled):hover .ui-icon,body .ui-selectmanybutton>.ui-button.ui-state-active:not(.ui-state-disabled):hover .ui-icon{
@@ -635,52 +635,52 @@ body .ui-button.ui-button-help.ui-button-flat.ui-state-active,body .ui-splitbutt
     color:#9c27b0
 }
 body .ui-button.ui-button-info,body .ui-splitbutton.ui-button-info>.ui-button,body .ui-menubutton.ui-button-info>.ui-button{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff;
-    border:1px solid #78c2ad
+    border:1px solid #2c6e9c
 }
 body .ui-button.ui-button-info.ui-state-hover,body .ui-splitbutton.ui-button-info>.ui-button.ui-state-hover,body .ui-menubutton.ui-button-info>.ui-button.ui-state-hover{
-    background:#7fc5b1;
+    background:#1f4e70;
     color:#fff;
-    border-color:#7fc5b1
+    border-color:#1f4e70
 }
 body .ui-button.ui-button-info.ui-state-focus,body .ui-splitbutton.ui-button-info>.ui-button.ui-state-focus,body .ui-menubutton.ui-button-info>.ui-button.ui-state-focus{
     box-shadow:0 0 0 .2rem rgba(0, 0, 0, 0.1)
 }
 body .ui-button.ui-button-info.ui-state-active,body .ui-splitbutton.ui-button-info>.ui-button.ui-state-active,body .ui-menubutton.ui-button-info>.ui-button.ui-state-active{
-    background:#86c8b5;
+    background:#3e8cc4;
     color:#fff;
-    border-color:#86c8b5
+    border-color:#3e8cc4
 }
 body .ui-button.ui-button-info.ui-button-outlined,body .ui-splitbutton.ui-button-info>.ui-button.ui-button-outlined,body .ui-menubutton.ui-button-info>.ui-button.ui-button-outlined{
     background-color:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border:1px solid
 }
 body .ui-button.ui-button-info.ui-button-outlined.ui-state-hover,body .ui-splitbutton.ui-button-info>.ui-button.ui-button-outlined.ui-state-hover,body .ui-menubutton.ui-button-info>.ui-button.ui-button-outlined.ui-state-hover{
     background:rgba(0,122,217,.04);
-    color:#78c2ad;
+    color:#2c6e9c;
     border:1px solid
 }
 body .ui-button.ui-button-info.ui-button-outlined.ui-state-active,body .ui-splitbutton.ui-button-info>.ui-button.ui-button-outlined.ui-state-active,body .ui-menubutton.ui-button-info>.ui-button.ui-button-outlined.ui-state-active{
     background:rgba(0,122,217,.16);
-    color:#78c2ad;
+    color:#2c6e9c;
     border:1px solid
 }
 body .ui-button.ui-button-info.ui-button-flat,body .ui-splitbutton.ui-button-info>.ui-button.ui-button-flat,body .ui-menubutton.ui-button-info>.ui-button.ui-button-flat{
     background-color:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-button.ui-button-info.ui-button-flat.ui-state-hover,body .ui-splitbutton.ui-button-info>.ui-button.ui-button-flat.ui-state-hover,body .ui-menubutton.ui-button-info>.ui-button.ui-button-flat.ui-state-hover{
     background:rgba(0,122,217,.04);
     border-color:transparent;
-    color:#78c2ad
+    color:#2c6e9c
 }
 body .ui-button.ui-button-info.ui-button-flat.ui-state-active,body .ui-splitbutton.ui-button-info>.ui-button.ui-button-flat.ui-state-active,body .ui-menubutton.ui-button-info>.ui-button.ui-button-flat.ui-state-active{
     background:rgba(0,122,217,.16);
     border-color:transparent;
-    color:#78c2ad
+    color:#2c6e9c
 }
 body .ui-button.ui-button-danger,body .ui-splitbutton.ui-button-danger>.ui-button,body .ui-menubutton.ui-button-danger>.ui-button{
     background:#e91224;
@@ -731,15 +731,15 @@ body .ui-button.ui-button-danger.ui-button-flat.ui-state-active,body .ui-splitbu
     color:#e91224
 }
 body .ui-commandlink,body .ui-link{
-    color:#78c2ad;
+    color:#2c6e9c;
     transition:background-color .2s,color .2s,border-color .2s,box-shadow .2s,opacity .2s
 }
 body .ui-commandlink:hover,body .ui-link:hover{
-    color:#7fc5b1;
+    color:#1f4e70;
     text-decoration:underline
 }
 body .ui-commandlink:active,body .ui-link:active{
-    color:#86c8b5
+    color:#3e8cc4
 }
 body .ui-splitbutton{
     padding:0
@@ -874,7 +874,7 @@ body .ui-carousel .ui-carousel-content .ui-carousel-prev,body .ui-carousel .ui-c
 }
 body .ui-carousel .ui-carousel-content .ui-carousel-prev:hover,body .ui-carousel .ui-carousel-content .ui-carousel-next:hover{
     background:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-carousel .ui-carousel-content .ui-carousel-prev:focus,body .ui-carousel .ui-carousel-content .ui-carousel-next:focus{
@@ -900,7 +900,7 @@ body .ui-carousel .ui-carousel-indicators .ui-carousel-indicator button:hover{
     background:#dfe0e1
 }
 body .ui-carousel .ui-carousel-indicators .ui-carousel-indicator.ui-state-highlight button{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-chronoline .ui-chronoline-event-marker{
@@ -908,7 +908,7 @@ body .ui-chronoline .ui-chronoline-event-marker{
     border-radius:50%;
     width:1rem;
     height:1rem;
-    background-color:#78c2ad
+    background-color:#2c6e9c
 }
 body .ui-chronoline .ui-chronoline-event-connector{
     background-color:#ecedee
@@ -1093,7 +1093,7 @@ body .ui-datatable thead th .ui-sortable-column-badge{
     min-width:1.143rem;
     line-height:1.143rem;
     color:#fff;
-    background:#78c2ad;
+    background:#2c6e9c;
     margin-left:.5rem;
     font-size:.75rem
 }
@@ -1107,11 +1107,11 @@ body .ui-datatable thead th.ui-state-hover{
     color:#333
 }
 body .ui-datatable thead th.ui-state-active{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-datatable thead th.ui-state-active.ui-state-hover{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-datatable .ui-datatable-data>tr{
@@ -1135,7 +1135,7 @@ body .ui-datatable .ui-datatable-data>tr.ui-state-hover{
     color:#333
 }
 body .ui-datatable .ui-datatable-data>tr.ui-state-highlight{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-datatable .ui-datatable-data>tr.ui-state-highlight .ui-row-toggler{
@@ -1170,7 +1170,7 @@ body .ui-datatable .ui-datatable-data>tr .ui-row-editor>a{
 }
 body .ui-datatable .ui-datatable-data>tr .ui-row-editor>a:hover{
     background:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-datatable .ui-datatable-data>tr .ui-row-editor>a:focus{
@@ -1226,7 +1226,7 @@ body .ui-datatable .ui-datatable-data>tr .ui-row-toggler{
 }
 body .ui-datatable .ui-datatable-data>tr .ui-row-toggler:hover{
     background:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-datatable .ui-datatable-data>tr .ui-row-toggler:focus{
@@ -1272,7 +1272,7 @@ body .ui-datatable .ui-datatable-data>tr .ui-rowgroup-toggler .ui-rowgroup-toggl
 }
 body .ui-datatable .ui-datatable-data>tr .ui-rowgroup-toggler .ui-rowgroup-toggler-icon:hover{
     background:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-datatable .ui-datatable-data>tr .ui-rowgroup-toggler .ui-rowgroup-toggler-icon:focus{
@@ -1301,10 +1301,10 @@ body .ui-datatable .ui-datatable-data>tr .ui-rowgroup-toggler .ui-rowgroup-toggl
     content:""
 }
 body .ui-datatable .ui-datatable-data>tr.ui-datatable-rowordering{
-    background:#78c2ad
+    background:#2c6e9c
 }
 body .ui-datatable .ui-column-resizer-helper{
-    background:#78c2ad
+    background:#2c6e9c
 }
 body .ui-datatable tfoot td{
     background:#f4f4f4;
@@ -1357,7 +1357,7 @@ body .ui-datatable.ui-datatable-striped .ui-datatable-data>tr.ui-datatable-odd.u
     color:#333
 }
 body .ui-datatable.ui-datatable-striped .ui-datatable-data>tr.ui-datatable-odd.ui-state-highlight{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-datatable.ui-datatable-sm thead>tr>th{
@@ -1493,7 +1493,7 @@ body .fc .fc-scrollgrid{
     border-color:#ecedee
 }
 body .fc .fc-daygrid-day.fc-day-today,body .fc .fc-timegrid-col.fc-day-today{
-    background-color:#78c2ad
+    background-color:#2c6e9c
 }
 body .fc th{
     background:#f4f4f4;
@@ -1518,8 +1518,8 @@ body .fc .fc-row{
     border-right:1px solid #ecedee
 }
 body .fc .fc-event,body .fc .fc-event .fc-event-main{
-    background:#7fc5b1;
-    border:1px solid #7fc5b1;
+    background:#1f4e70;
+    border:1px solid #1f4e70;
     color:#fff
 }
 body .fc .fc-divider{
@@ -1527,14 +1527,14 @@ body .fc .fc-divider{
     border:1px solid #ecedee
 }
 body .fc .fc-toolbar .fc-button{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff;
-    border:1px solid #78c2ad;
+    border:1px solid #2c6e9c;
     transition:background-color .2s,color .2s,border-color .2s,box-shadow .2s,opacity .2s
 }
 body .fc .fc-toolbar .fc-button:not(:disabled):hover{
-    background:#7fc5b1;
-    border-color:#7fc5b1;
+    background:#1f4e70;
+    border-color:#1f4e70;
     color:#fff
 }
 body .fc .fc-toolbar .fc-button:focus{
@@ -1543,8 +1543,8 @@ body .fc .fc-toolbar .fc-button:focus{
     box-shadow:0 0 0 .1em rgba(0, 0, 0, 0.1)
 }
 body .fc .fc-toolbar .fc-button:active,body .fc .fc-toolbar .fc-button.fc-button-active{
-    background:#86c8b5;
-    border-color:#86c8b5;
+    background:#3e8cc4;
+    border-color:#3e8cc4;
     color:#fff
 }
 body .ui-fluid .fc .fc-toolbar .ui-button{
@@ -1641,7 +1641,7 @@ body .ui-orderlist .ui-orderlist-list .ui-orderlist-item.ui-state-hover{
     color:#333
 }
 body .ui-orderlist .ui-orderlist-list .ui-orderlist-item.ui-state-highlight{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-orderlist .ui-orderlist-list .ui-orderlist-item.ui-state-highlight.ui-sortable-placeholder{
@@ -1771,7 +1771,7 @@ body .ui-paginator .ui-paginator-pages .ui-paginator-page{
     transition:background-color .2s,color .2s,border-color .2s,box-shadow .2s,opacity .2s
 }
 body .ui-paginator .ui-paginator-pages .ui-paginator-page.ui-state-active{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-paginator .ui-paginator-pages .ui-paginator-page.ui-state-hover{
@@ -1928,7 +1928,7 @@ body .ui-picklist .ui-picklist-list .ui-picklist-item.ui-state-hover{
     color:#333
 }
 body .ui-picklist .ui-picklist-list .ui-picklist-item.ui-state-highlight{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-picklist .ui-picklist-list .ui-picklist-item.ui-state-highlight.ui-sortable-placeholder{
@@ -1998,7 +1998,7 @@ body .ui-tagcloud a{
     transition:background-color .2s,color .2s,border-color .2s,box-shadow .2s,opacity .2s
 }
 body .ui-tagcloud a.ui-state-hover{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .timeline-frame{
@@ -2021,7 +2021,7 @@ body .timeline-frame .timeline-navigation{
 }
 body .timeline-frame .timeline-navigation:hover{
     background:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .timeline-frame .timeline-navigation:focus{
@@ -2075,7 +2075,7 @@ body .timeline-frame .timeline-event{
     color:#333
 }
 body .timeline-frame .timeline-event.ui-state-active{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .vis-timeline{
@@ -2095,8 +2095,8 @@ body .vis-timeline .vis-item.vis-dot{
     border-width:4px
 }
 body .vis-timeline .vis-item.vis-selected{
-    background:#78c2ad;
-    border-color:#78c2ad
+    background:#2c6e9c;
+    border-color:#2c6e9c
 }
 body .vis-timeline .vis-item.vis-selected .vis-item-content{
     color:#fff
@@ -2147,7 +2147,7 @@ body .ui-tree .ui-tree-container .ui-treenode .ui-treenode-content .ui-tree-togg
 }
 body .ui-tree .ui-tree-container .ui-treenode .ui-treenode-content .ui-tree-toggler:hover{
     background:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-tree .ui-tree-container .ui-treenode .ui-treenode-content .ui-tree-toggler:focus{
@@ -2203,7 +2203,7 @@ body .ui-tree .ui-tree-container .ui-treenode .ui-treenode-content .ui-treenode-
     color:#333
 }
 body .ui-tree .ui-tree-container .ui-treenode .ui-treenode-content .ui-treenode-label.ui-state-highlight{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-tree .ui-tree-container .ui-treenode .ui-treenode-content .ui-chkbox{
@@ -2221,7 +2221,7 @@ body .ui-tree .ui-tree-container .ui-treenode .ui-treenode-content .ui-chkbox .u
     content:""
 }
 body .ui-tree .ui-tree-container .ui-treenode .ui-treenode-content.ui-state-highlight{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-tree .ui-tree-container .ui-treenode .ui-treenode-content.ui-state-highlight .ui-tree-toggler,body .ui-tree .ui-tree-container .ui-treenode .ui-treenode-content.ui-state-highlight .ui-treenode-icon{
@@ -2235,7 +2235,7 @@ body .ui-tree .ui-tree-container .ui-treenode .ui-treenode-content.ui-treenode-s
     color:#333
 }
 body .ui-tree .ui-tree-container .ui-tree-droppoint.ui-state-hover{
-    background:#78c2ad
+    background:#2c6e9c
 }
 body .ui-tree .ui-tree-container .ui-treenode-outline{
     outline:0 none;
@@ -2258,7 +2258,7 @@ body .ui-tree.ui-tree-horizontal .ui-treenode-content.ui-state-hover{
     color:#333
 }
 body .ui-tree.ui-tree-horizontal .ui-treenode-content.ui-state-highlight{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-tree.ui-tree-horizontal .ui-treenode-content .ui-tree-toggler{
@@ -2350,7 +2350,7 @@ body .ui-tree.ui-tree-rtl .ui-tree-container .ui-treenode .ui-treenode-content .
     margin-left:2.5rem
 }
 body .ui-tree-draghelper{
-    border:1px solid #78c2ad
+    border:1px solid #2c6e9c
 }
 body .ui-fluid .ui-tree{
     width:100%
@@ -2444,7 +2444,7 @@ body .ui-treetable thead th .ui-sortable-column-badge{
     min-width:1.143rem;
     line-height:1.143rem;
     color:#fff;
-    background:#78c2ad;
+    background:#2c6e9c;
     margin-left:.5rem;
     font-size:.75rem
 }
@@ -2458,11 +2458,11 @@ body .ui-treetable thead th.ui-state-hover{
     color:#333
 }
 body .ui-treetable thead th.ui-state-active{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-treetable thead th.ui-state-active.ui-state-hover{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-treetable .ui-treetable-data>tr{
@@ -2493,7 +2493,7 @@ body .ui-treetable .ui-treetable-data>tr>td .ui-treetable-toggler{
 }
 body .ui-treetable .ui-treetable-data>tr>td .ui-treetable-toggler:hover{
     background:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-treetable .ui-treetable-data>tr>td .ui-treetable-toggler:focus{
@@ -2541,7 +2541,7 @@ body .ui-treetable .ui-treetable-data>tr.ui-state-hover{
     color:#333
 }
 body .ui-treetable .ui-treetable-data>tr.ui-state-highlight{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff;
     cursor:default
 }
@@ -2566,7 +2566,7 @@ body .ui-treetable .ui-treetable-data>tr .ui-row-editor .ui-icon{
 }
 body .ui-treetable .ui-treetable-data>tr .ui-row-editor .ui-icon:hover{
     background:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-treetable .ui-treetable-data>tr .ui-row-editor .ui-icon:focus{
@@ -2634,7 +2634,7 @@ body .ui-treetable .ui-treetable-scrollable-header,body .ui-treetable .ui-treeta
     background:#f4f4f4
 }
 body .ui-treetable .ui-column-resizer-helper{
-    background:#78c2ad
+    background:#2c6e9c
 }
 body .ui-treetable.ui-treetable-sm thead>tr>th{
     padding:.2855rem .4285rem
@@ -2800,7 +2800,7 @@ body .ui-autocomplete .ui-autocomplete-multiple-container{
 body .ui-autocomplete .ui-autocomplete-multiple-container .ui-autocomplete-token{
     padding:1px 0;
     margin:0 .5rem 0 0;
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff;
     display:inline-block;
     vertical-align:middle;
@@ -2877,14 +2877,14 @@ body .ui-autocomplete-panel .ui-autocomplete-items .ui-autocomplete-item.ui-auto
     padding:.571rem .857rem
 }
 body .ui-autocomplete-panel .ui-autocomplete-items .ui-autocomplete-item.ui-state-highlight{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-autocomplete-itemtip{
     padding:0
 }
 body .ui-autocomplete-itemtip.ui-state-highlight{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-fluid .ui-autocomplete .ui-autocomplete-input.ui-autocomplete-dd-input{
@@ -2906,7 +2906,7 @@ body .ui-cascadeselect:not(.ui-state-disabled):hover{
     border-color:#000
 }
 body .ui-cascadeselect:not(.ui-state-disabled).ui-state-focus{
-    border-color:#78c2ad;
+    border-color:#2c6e9c;
     outline:0 none;
     box-shadow:0 0 .2rem #666
 }
@@ -2956,7 +2956,7 @@ body .ui-cascadeselect-panel .ui-cascadeselect-items .ui-cascadeselect-item .ui-
 }
 body .ui-cascadeselect-panel .ui-cascadeselect-items .ui-cascadeselect-item.ui-state-highlight{
     color:#fff;
-    background:#78c2ad
+    background:#2c6e9c
 }
 body .ui-cascadeselect-panel .ui-cascadeselect-items .ui-cascadeselect-item:not(.ui-state-highlight):not(.ui-state-disabled):hover{
     color:#333;
@@ -3000,12 +3000,12 @@ body .ui-chkbox .ui-chkbox-box.ui-state-focus{
     outline:0 none
 }
 body .ui-chkbox .ui-chkbox-box.ui-state-active{
-    border-color:#78c2ad;
-    background:#78c2ad;
+    border-color:#2c6e9c;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-chkbox .ui-chkbox-box.ui-state-active.ui-state-hover{
-    background:#86c8b5
+    background:#3e8cc4
 }
 body .ui-chkbox .ui-chkbox-box.ui-state-error{
     border-color:#a80000
@@ -3045,10 +3045,10 @@ body.ui-input-filled .ui-chkbox .ui-chkbox-box.ui-state-hover,body .ui-input-fil
     background-color:#f4f4f4
 }
 body.ui-input-filled .ui-chkbox .ui-chkbox-box.ui-state-active,body .ui-input-filled .ui-chkbox .ui-chkbox-box.ui-state-active{
-    background:#78c2ad
+    background:#2c6e9c
 }
 body.ui-input-filled .ui-chkbox .ui-chkbox-box.ui-state-active.ui-state-hover,body .ui-input-filled .ui-chkbox .ui-chkbox-box.ui-state-active.ui-state-hover{
-    background:#86c8b5
+    background:#3e8cc4
 }
 body .ui-state-highlight .ui-chkbox .ui-chkbox-box.ui-state-active{
     border-color:#fff
@@ -3059,7 +3059,7 @@ body .ui-chips .ui-chips-container{
 body .ui-chips .ui-chips-container .ui-chips-token{
     padding:1px 0;
     margin:.125rem;
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff;
     border-radius:3px
 }
@@ -3157,7 +3157,7 @@ body .ui-datepicker .ui-datepicker-next,body .ui-datepicker .ui-datepicker-prev{
 }
 body .ui-datepicker .ui-datepicker-next:hover,body .ui-datepicker .ui-datepicker-prev:hover{
     background:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-datepicker .ui-datepicker-next:focus,body .ui-datepicker .ui-datepicker-prev:focus{
@@ -3216,7 +3216,7 @@ body .ui-datepicker .ui-datepicker-calendar td>a:focus,body .ui-datepicker .ui-d
     box-shadow:0 0 0 .2rem rgba(0, 0, 0, 0.1)
 }
 body .ui-datepicker .ui-datepicker-calendar td>a.ui-state-active,body .ui-datepicker .ui-datepicker-calendar td>span.ui-state-active{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff;
     border:0 none
 }
@@ -3231,7 +3231,7 @@ body .ui-datepicker .ui-datepicker-calendar td.ui-datepicker-today>a,body .ui-da
     border:0 none
 }
 body .ui-datepicker .ui-datepicker-calendar td.ui-datepicker-today>a.ui-state-active,body .ui-datepicker .ui-datepicker-calendar td.ui-datepicker-today>span.ui-state-active,body .ui-datepicker .ui-datepicker-calendar td.ui-datepicker-current-day>a.ui-state-active,body .ui-datepicker .ui-datepicker-calendar td.ui-datepicker-current-day>span.ui-state-active{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff;
     border:0 none
 }
@@ -3269,7 +3269,7 @@ body .ui-datepicker .ui-timepicker-timeinput input:hover{
     border-color:#000
 }
 body .ui-datepicker .ui-timepicker-timeinput input:focus{
-    border-color:#78c2ad;
+    border-color:#2c6e9c;
     outline:0 none;
     box-shadow:0 0 .2rem #666
 }
@@ -3354,7 +3354,7 @@ body .ui-datepicker .ui-monthpicker-month:focus{
     box-shadow:0 0 0 .2rem rgba(0, 0, 0, 0.1)
 }
 body .ui-datepicker .ui-monthpicker-month.ui-state-active{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff;
     border:0 none
 }
@@ -3376,7 +3376,7 @@ body .ui-datepicker .ui-picker-up{
 }
 body .ui-datepicker .ui-picker-up:hover{
     background:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-datepicker .ui-picker-up:focus{
@@ -3409,7 +3409,7 @@ body .ui-datepicker .ui-picker-down{
 }
 body .ui-datepicker .ui-picker-down:hover{
     background:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-datepicker .ui-picker-down:focus{
@@ -3474,7 +3474,7 @@ body .ui-inplace .ui-inplace-display.ui-state-highlight{
     transition:background-color .2s,color .2s,border-color .2s,box-shadow .2s,opacity .2s
 }
 body .ui-inplace .ui-inplace-display.ui-state-focus{
-    border-color:#78c2ad;
+    border-color:#2c6e9c;
     outline:0 none;
     box-shadow:0 0 .2rem #666
 }
@@ -3576,7 +3576,7 @@ body .ui-inputfield.ui-state-hover{
     border-color:#000
 }
 body .ui-inputfield.ui-state-focus{
-    border-color:#78c2ad;
+    border-color:#2c6e9c;
     outline:0 none;
     box-shadow:0 0 .2rem #666
 }
@@ -3668,7 +3668,7 @@ body .ui-inputswitch .ui-inputswitch-handle{
     box-shadow:0px 3px 1px -2px rgba(0,0,0,.2),0px 2px 2px 0px rgba(0,0,0,.14),0px 1px 5px 0px rgba(0,0,0,.12)
 }
 body .ui-inputswitch .ui-inputswitch-handle.ui-state-focus{
-    border-color:#78c2ad;
+    border-color:#2c6e9c;
     outline:0 none;
     box-shadow:0 0 .2rem #666
 }
@@ -3679,11 +3679,11 @@ body .ui-inputswitch .ui-inputswitch-off span,body .ui-inputswitch .ui-inputswit
     visibility:hidden
 }
 body .ui-inputswitch.ui-inputswitch-checked{
-    background:#78c2ad
+    background:#2c6e9c
 }
 body .ui-inputswitch.ui-inputswitch-checked .ui-inputswitch-handle{
     background:#ccc;
-    border-color:#7fc5b1;
+    border-color:#1f4e70;
     margin-left:2px
 }
 body .keypad-popup{
@@ -3711,18 +3711,18 @@ body .keypad-popup button.ui-state-hover{
     color:#333
 }
 body .keypad-popup button.ui-state-active{
-    background:#86c8b5;
-    border-color:#86c8b5;
+    background:#3e8cc4;
+    border-color:#3e8cc4;
     color:#fff
 }
 body .keypad-popup button.keypad-shift,body .keypad-popup button.keypad-spacebar,body .keypad-popup button.keypad-enter,body .keypad-popup button.keypad-clear,body .keypad-popup button.keypad-back,body .keypad-popup button.keypad-close{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff;
-    border:1px solid #78c2ad
+    border:1px solid #2c6e9c
 }
 body .keypad-popup button.keypad-shift.ui-state-hover,body .keypad-popup button.keypad-spacebar.ui-state-hover,body .keypad-popup button.keypad-enter.ui-state-hover,body .keypad-popup button.keypad-clear.ui-state-hover,body .keypad-popup button.keypad-back.ui-state-hover,body .keypad-popup button.keypad-close.ui-state-hover{
-    background:#7fc5b1;
-    border-color:#7fc5b1;
+    background:#1f4e70;
+    border-color:#1f4e70;
     color:#fff
 }
 body .keypad-popup button.keypad-shift.ui-state-focus,body .keypad-popup button.keypad-spacebar.ui-state-focus,body .keypad-popup button.keypad-enter.ui-state-focus,body .keypad-popup button.keypad-clear.ui-state-focus,body .keypad-popup button.keypad-back.ui-state-focus,body .keypad-popup button.keypad-close.ui-state-focus{
@@ -3731,8 +3731,8 @@ body .keypad-popup button.keypad-shift.ui-state-focus,body .keypad-popup button.
     box-shadow:0 0 0 .1em rgba(0, 0, 0, 0.1)
 }
 body .keypad-popup button.keypad-shift.ui-state-active,body .keypad-popup button.keypad-spacebar.ui-state-active,body .keypad-popup button.keypad-enter.ui-state-active,body .keypad-popup button.keypad-clear.ui-state-active,body .keypad-popup button.keypad-back.ui-state-active,body .keypad-popup button.keypad-close.ui-state-active{
-    background:#86c8b5;
-    border-color:#86c8b5;
+    background:#3e8cc4;
+    border-color:#3e8cc4;
     color:#fff
 }
 body .ui-multiselectlistbox .ui-multiselectlistbox-listcontainer{
@@ -3766,7 +3766,7 @@ body .ui-multiselectlistbox .ui-multiselectlistbox-listcontainer .ui-multiselect
     color:#333
 }
 body .ui-multiselectlistbox .ui-multiselectlistbox-listcontainer .ui-multiselectlistbox-list .ui-multiselectlistbox-item.ui-state-highlight{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-password .ui-password-icon{
@@ -3828,12 +3828,12 @@ body .ui-radiobutton .ui-radiobutton-box.ui-state-focus{
     box-shadow:0 0 0 .2rem rgba(0, 0, 0, 0.1)
 }
 body .ui-radiobutton .ui-radiobutton-box.ui-state-active{
-    border-color:#78c2ad;
-    background:#78c2ad;
+    border-color:#2c6e9c;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-radiobutton .ui-radiobutton-box.ui-state-active.ui-state-hover{
-    background:#86c8b5
+    background:#3e8cc4
 }
 body .ui-radiobutton .ui-radiobutton-box.ui-state-active .ui-icon-bullet{
     background:#fff
@@ -3862,10 +3862,10 @@ body.ui-input-filled .ui-radiobutton .ui-radiobutton-box.ui-state-hover,body .ui
     background-color:#f4f4f4
 }
 body.ui-input-filled .ui-radiobutton .ui-radiobutton-box.ui-state-active,body .ui-input-filled .ui-radiobutton .ui-radiobutton-box.ui-state-active{
-    background:#78c2ad
+    background:#2c6e9c
 }
 body.ui-input-filled .ui-radiobutton .ui-radiobutton-box.ui-state-active.ui-state-hover,body .ui-input-filled .ui-radiobutton .ui-radiobutton-box.ui-state-active.ui-state-hover{
-    background:#86c8b5
+    background:#3e8cc4
 }
 body .ui-state-highlight .ui-radiobutton .ui-radiobutton-box.ui-state-active{
     border-color:#fff
@@ -3931,7 +3931,7 @@ body .ui-rating .ui-rating-star a:before{
     content:""
 }
 body .ui-rating .ui-rating-star a:hover{
-    color:#78c2ad
+    color:#2c6e9c
 }
 body .ui-rating .ui-rating-star-on a{
     font-family:"primeicons" !important;
@@ -3943,7 +3943,7 @@ body .ui-rating .ui-rating-star-on a{
     font-size:1.143rem;
     height:1.143rem;
     width:1.143rem;
-    color:#78c2ad
+    color:#2c6e9c
 }
 body .ui-rating .ui-rating-star-on a:before{
     content:""
@@ -4011,7 +4011,7 @@ body .ui-selectcheckboxmenu.ui-state-hover{
     border-color:#000
 }
 body .ui-selectcheckboxmenu.ui-state-focus{
-    border-color:#78c2ad;
+    border-color:#2c6e9c;
     outline:0 none;
     box-shadow:0 0 .2rem #666
 }
@@ -4025,7 +4025,7 @@ body .ui-selectcheckboxmenu .ui-selectcheckboxmenu-multiple-container.ui-inputfi
 body .ui-selectcheckboxmenu .ui-selectcheckboxmenu-multiple-container .ui-selectcheckboxmenu-token{
     padding:1px 0;
     margin:0 .5rem 0 0;
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff;
     border-radius:3px
 }
@@ -4132,7 +4132,7 @@ body .ui-selectcheckboxmenu-panel .ui-selectcheckboxmenu-header .ui-selectcheckb
 }
 body .ui-selectcheckboxmenu-panel .ui-selectcheckboxmenu-header .ui-selectcheckboxmenu-close:hover{
     background:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-selectcheckboxmenu-panel .ui-selectcheckboxmenu-header .ui-selectcheckboxmenu-close:focus{
@@ -4168,7 +4168,7 @@ body .ui-selectcheckboxmenu-panel .ui-selectcheckboxmenu-items .ui-selectcheckbo
     color:#333
 }
 body .ui-selectcheckboxmenu-panel .ui-selectcheckboxmenu-items .ui-selectcheckboxmenu-item.ui-state-highlight{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-selectcheckboxmenu-panel .ui-selectcheckboxmenu-items .ui-selectcheckboxmenu-item .ui-chkbox{
@@ -4250,7 +4250,7 @@ body .ui-selectonelistbox .ui-selectlistbox-listcontainer .ui-selectlistbox-list
     color:#333
 }
 body .ui-selectonelistbox .ui-selectlistbox-listcontainer .ui-selectlistbox-list .ui-selectlistbox-item.ui-state-highlight,body .ui-selectmanymenu .ui-selectlistbox-listcontainer .ui-selectlistbox-list .ui-selectlistbox-item.ui-state-highlight{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-selectonelistbox .ui-selectlistbox-listcontainer .ui-selectlistbox-list .ui-selectlistbox-item .ui-chkbox,body .ui-selectmanymenu .ui-selectlistbox-listcontainer .ui-selectlistbox-list .ui-selectlistbox-item .ui-chkbox{
@@ -4316,7 +4316,7 @@ body .ui-selectonemenu.ui-state-hover{
     border-color:#000
 }
 body .ui-selectonemenu.ui-state-focus{
-    border-color:#78c2ad;
+    border-color:#2c6e9c;
     outline:0 none;
     box-shadow:0 0 .2rem #666
 }
@@ -4409,7 +4409,7 @@ body .ui-selectonemenu-panel .ui-selectonemenu-items .ui-selectonemenu-item.ui-s
     color:#333
 }
 body .ui-selectonemenu-panel .ui-selectonemenu-items .ui-selectonemenu-item.ui-state-highlight{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff;
     overflow:auto
 }
@@ -4431,7 +4431,7 @@ body .ui-slider .ui-slider-handle{
     border-radius:100%
 }
 body .ui-slider .ui-slider-handle.ui-state-hover{
-    border-color:#78c2ad;
+    border-color:#2c6e9c;
     background:#666
 }
 body .ui-slider .ui-slider-handle.ui-state-focus{
@@ -4452,7 +4452,7 @@ body .ui-slider.ui-slider-vertical .ui-slider-handle{
     margin-top:-0.5715rem
 }
 body .ui-slider .ui-slider-range{
-    background:#78c2ad
+    background:#2c6e9c
 }
 body .ui-inputtext+.ui-slider{
     margin-bottom:.5rem
@@ -4578,16 +4578,16 @@ body .ui-fluid .ui-spinner .ui-spinner-input{
     fill:#333
 }
 .ui-texteditor .ql-snow.ql-toolbar button.ql-active,.ui-texteditor .ql-snow.ql-toolbar .ql-picker-label.ql-active,.ui-texteditor .ql-snow.ql-toolbar .ql-picker-item.ql-selected{
-    color:#78c2ad
+    color:#2c6e9c
 }
 .ui-texteditor .ql-snow.ql-toolbar button.ql-active .ql-stroke,.ui-texteditor .ql-snow.ql-toolbar .ql-picker-label.ql-active .ql-stroke,.ui-texteditor .ql-snow.ql-toolbar .ql-picker-item.ql-selected .ql-stroke{
-    stroke:#78c2ad
+    stroke:#2c6e9c
 }
 .ui-texteditor .ql-snow.ql-toolbar button.ql-active .ql-fill,.ui-texteditor .ql-snow.ql-toolbar .ql-picker-label.ql-active .ql-fill,.ui-texteditor .ql-snow.ql-toolbar .ql-picker-item.ql-selected .ql-fill{
-    fill:#78c2ad
+    fill:#2c6e9c
 }
 .ui-texteditor .ql-snow.ql-toolbar button.ql-active .ql-picker-label,.ui-texteditor .ql-snow.ql-toolbar .ql-picker-label.ql-active .ql-picker-label,.ui-texteditor .ql-snow.ql-toolbar .ql-picker-item.ql-selected .ql-picker-label{
-    color:#78c2ad
+    color:#2c6e9c
 }
 .ui-texteditor.ui-state-error .ui-editor-toolbar.ql-snow,.ui-texteditor.ui-state-error .ql-container.ql-snow{
     border-color:#a80000
@@ -4642,7 +4642,7 @@ body .ui-toggleswitch.ui-toggleswitch-focus .ui-toggleswitch-slider{
     box-shadow:0 0 0 .2rem rgba(0, 0, 0, 0.1)
 }
 body .ui-toggleswitch.ui-toggleswitch-checked .ui-toggleswitch-slider{
-    background:#78c2ad
+    background:#2c6e9c
 }
 body .ui-toggleswitch.ui-toggleswitch-checked .ui-toggleswitch-slider:before,body .ui-toggleswitch.ui-toggleswitch-checked .ui-toggleswitch-slider .ui-toggleswitch-handler{
     background:#ccc
@@ -5130,13 +5130,13 @@ body .ui-panelmenu h3.ui-panelmenu-header.ui-state-hover{
     color:#333
 }
 body .ui-panelmenu h3.ui-panelmenu-header.ui-state-active{
-    border-color:#78c2ad;
+    border-color:#2c6e9c;
     background:#f4f4f4;
     color:#fff
 }
 body .ui-panelmenu h3.ui-panelmenu-header.ui-state-active:hover{
-    border-color:#86c8b5;
-    background:#86c8b5;
+    border-color:#3e8cc4;
+    background:#3e8cc4;
     color:#333
 }
 body .ui-panelmenu .ui-panelmenu-content{
@@ -5239,9 +5239,9 @@ body .ui-steps .ui-steps-item .ui-menuitem-link .ui-steps-title{
     color:#848484
 }
 body .ui-steps .ui-steps-item.ui-state-highlight .ui-steps-number{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff;
-    border-color:#78c2ad
+    border-color:#2c6e9c
 }
 body .ui-steps .ui-steps-item.ui-state-highlight .ui-steps-title{
     font-weight:600;
@@ -5323,8 +5323,8 @@ body .ui-tabmenu .ui-tabmenu-nav .ui-tabmenuitem.ui-state-hover a .ui-icon{
     color:#333
 }
 body .ui-tabmenu .ui-tabmenu-nav .ui-tabmenuitem.ui-state-active{
-    background:#78c2ad;
-    border-color:#78c2ad
+    background:#2c6e9c;
+    border-color:#2c6e9c
 }
 body .ui-tabmenu .ui-tabmenu-nav .ui-tabmenuitem.ui-state-active a{
     color:#fff
@@ -5351,7 +5351,7 @@ body .ui-tabmenu.ui-tabs-bottom .ui-tabmenu-nav .ui-tabmenuitem.ui-state-hover{
     border-color:#dbdbdb
 }
 body .ui-tabmenu.ui-tabs-bottom .ui-tabmenu-nav .ui-tabmenuitem.ui-state-active{
-    border-color:#78c2ad
+    border-color:#2c6e9c
 }
 body .ui-tabmenu.ui-tabs-left .ui-tabmenu-nav{
     flex-direction:column
@@ -5372,7 +5372,7 @@ body .ui-tabmenu.ui-tabs-left .ui-tabmenu-nav .ui-tabmenuitem.ui-state-hover{
     border-color:#dbdbdb
 }
 body .ui-tabmenu.ui-tabs-left .ui-tabmenu-nav .ui-tabmenuitem.ui-state-active{
-    border-color:#78c2ad
+    border-color:#2c6e9c
 }
 body .ui-tabmenu.ui-tabs-right .ui-tabmenu-nav{
     flex-direction:column
@@ -5391,7 +5391,7 @@ body .ui-tabmenu.ui-tabs-right .ui-tabmenu-nav .ui-tabmenuitem.ui-state-hover{
     border-color:#dbdbdb
 }
 body .ui-tabmenu.ui-tabs-right .ui-tabmenu-nav .ui-tabmenuitem.ui-state-active{
-    border-color:#78c2ad
+    border-color:#2c6e9c
 }
 body .ui-growl{
     top:85px
@@ -5612,7 +5612,7 @@ body .ui-messages .ui-messages-close{
 }
 body .ui-messages .ui-messages-close:hover{
     background:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-messages .ui-messages-close:focus{
@@ -5732,7 +5732,7 @@ body .ui-avatar-group .ui-avatar{
     border:2px solid #fff
 }
 body .ui-badge{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff;
     font-size:.75rem;
     font-weight:700;
@@ -5754,7 +5754,7 @@ body .ui-badge.ui-badge-success{
     color:#fff
 }
 body .ui-badge.ui-badge-info{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-badge.ui-badge-warning{
@@ -5789,7 +5789,7 @@ body .ui-overlay-badge .ui-badge{
     margin:0
 }
 body .ui-chip{
-    background-color:#78c2ad;
+    background-color:#2c6e9c;
     color:#fff;
     border-radius:16px;
     padding:0 .429rem
@@ -5894,7 +5894,7 @@ body .ui-galleria .ui-galleria-indicators .ui-galleria-indicator button:hover{
     background:#dfe0e1
 }
 body .ui-galleria .ui-galleria-indicators .ui-galleria-indicator.ui-state-highlight button{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-galleria.ui-galleria-indicators-bottom .ui-galleria-indicator,body .ui-galleria.ui-galleria-indicators-top .ui-galleria-indicator{
@@ -5913,7 +5913,7 @@ body .ui-galleria.ui-galleria-indicator-onitem .ui-galleria-indicators .ui-galle
     background:rgba(255,255,255,.6)
 }
 body .ui-galleria.ui-galleria-indicator-onitem .ui-galleria-indicators .ui-galleria-indicator.ui-state-highlight button{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-galleria .ui-galleria-thumbnail-container{
@@ -6029,7 +6029,7 @@ body .ui-log .ui-log-header .ui-log-button{
 }
 body .ui-log .ui-log-header .ui-log-button:hover{
     background:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-log .ui-log-header .ui-log-button:focus{
@@ -6114,7 +6114,7 @@ body .ui-progressbar{
 body .ui-progressbar .ui-progressbar-value{
     border:0 none;
     margin:0;
-    background:#78c2ad;
+    background:#2c6e9c;
     border-radius:3px
 }
 body .ui-progressbar .ui-progressbar-label{
@@ -6145,7 +6145,7 @@ body .ui-skeleton:after{
     background:linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0))
 }
 body .ui-tag{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff;
     font-size:.75rem;
     font-weight:700;
@@ -6162,7 +6162,7 @@ body .ui-tag.ui-tag-success{
     color:#fff
 }
 body .ui-tag.ui-tag-info{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-tag.ui-tag-warning{
@@ -6265,7 +6265,7 @@ body .ui-dialog .ui-dialog-titlebar .ui-dialog-titlebar-icon{
 }
 body .ui-dialog .ui-dialog-titlebar .ui-dialog-titlebar-icon:hover{
     background:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-dialog .ui-dialog-titlebar .ui-dialog-titlebar-icon:focus{
@@ -6473,7 +6473,7 @@ body .ui-lightbox .ui-lightbox-caption .ui-lightbox-close{
 }
 body .ui-lightbox .ui-lightbox-caption .ui-lightbox-close:hover{
     background:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-lightbox .ui-lightbox-caption .ui-lightbox-close:focus{
@@ -6561,7 +6561,7 @@ body .ui-overlaypanel .ui-overlaypanel-close{
     height:2rem;
     right:-1rem;
     top:-1rem;
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff;
     transition:background-color .2s,color .2s,border-color .2s,box-shadow .2s,opacity .2s;
     border-radius:50%;
@@ -6570,7 +6570,7 @@ body .ui-overlaypanel .ui-overlaypanel-close{
     padding:0
 }
 body .ui-overlaypanel .ui-overlaypanel-close:hover{
-    background:#7fc5b1;
+    background:#1f4e70;
     color:#fff
 }
 body .ui-overlaypanel .ui-overlaypanel-close .ui-icon{
@@ -6608,7 +6608,7 @@ body .ui-sidebar .ui-sidebar-close{
 }
 body .ui-sidebar .ui-sidebar-close:hover{
     background:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-sidebar .ui-sidebar-close:focus{
@@ -6683,13 +6683,13 @@ body .ui-accordion .ui-accordion-header.ui-state-hover{
     color:#333
 }
 body .ui-accordion .ui-accordion-header.ui-state-active{
-    background:#78c2ad;
-    border-color:#78c2ad;
+    background:#2c6e9c;
+    border-color:#2c6e9c;
     color:#fff
 }
 body .ui-accordion .ui-accordion-header.ui-state-active:hover{
-    border-color:#86c8b5;
-    background:#86c8b5;
+    border-color:#3e8cc4;
+    background:#3e8cc4;
     color:#333
 }
 body .ui-accordion .ui-accordion-header:focus{
@@ -6773,7 +6773,7 @@ body .ui-card .ui-card-footer{
     padding:1rem 0 0 0
 }
 body .ui-dashboard .ui-sortable-placeholder{
-    background-color:#78c2ad
+    background-color:#2c6e9c
 }
 body .ui-divider .ui-divider-content{
     background-color:#fff
@@ -6896,7 +6896,7 @@ body .ui-panel .ui-panel-titlebar .ui-panel-titlebar-icon{
 }
 body .ui-panel .ui-panel-titlebar .ui-panel-titlebar-icon:hover{
     background:transparent;
-    color:#78c2ad;
+    color:#2c6e9c;
     border-color:transparent
 }
 body .ui-panel .ui-panel-titlebar .ui-panel-titlebar-icon:focus{
@@ -7087,7 +7087,7 @@ body .ui-tabs .ui-tabs-nav li.ui-tabs-header.ui-state-hover .ui-icon{
     color:#333
 }
 body .ui-tabs .ui-tabs-nav li.ui-tabs-header.ui-state-active{
-    background:#78c2ad
+    background:#2c6e9c
 }
 body .ui-tabs .ui-tabs-nav li.ui-tabs-header.ui-state-active a{
     color:#fff
@@ -7149,7 +7149,7 @@ body .ui-tabs.ui-tabs-top>.ui-tabs-nav li.ui-tabs-header.ui-state-hover{
     border-color:#dbdbdb
 }
 body .ui-tabs.ui-tabs-top>.ui-tabs-nav li.ui-tabs-header.ui-state-active{
-    border-color:#78c2ad
+    border-color:#2c6e9c
 }
 body .ui-tabs.ui-tabs-top>.ui-tabs-nav li.ui-tabs-header.ui-state-error{
     border-color:#a80000
@@ -7183,7 +7183,7 @@ body .ui-tabs.ui-tabs-bottom>.ui-tabs-nav li.ui-tabs-header.ui-state-hover{
     border-color:#dbdbdb
 }
 body .ui-tabs.ui-tabs-bottom>.ui-tabs-nav li.ui-tabs-header.ui-state-active{
-    border-color:#78c2ad
+    border-color:#2c6e9c
 }
 body .ui-tabs.ui-tabs-bottom>.ui-tabs-nav li.ui-tabs-header.ui-state-error{
     border-color:#a80000
@@ -7219,7 +7219,7 @@ body .ui-tabs.ui-tabs-right>.ui-tabs-nav li.ui-tabs-header.ui-state-hover{
     border-color:#dbdbdb
 }
 body .ui-tabs.ui-tabs-right>.ui-tabs-nav li.ui-tabs-header.ui-state-active{
-    border-color:#78c2ad
+    border-color:#2c6e9c
 }
 body .ui-tabs.ui-tabs-right>.ui-tabs-nav li.ui-tabs-header.ui-state-error{
     border-color:#a80000
@@ -7241,7 +7241,7 @@ body .ui-tabs.ui-tabs-left>.ui-tabs-nav li.ui-tabs-header.ui-state-hover{
     border-color:#dbdbdb
 }
 body .ui-tabs.ui-tabs-left>.ui-tabs-nav li.ui-tabs-header.ui-state-active{
-    border-color:#78c2ad
+    border-color:#2c6e9c
 }
 body .ui-tabs.ui-tabs-left>.ui-tabs-nav li.ui-tabs-header.ui-state-error{
     border-color:#a80000
@@ -7324,7 +7324,7 @@ body .ui-wizard .ui-wizard-step-titles .ui-wizard-step-title:last-child{
     border-right:1px solid #ecedee
 }
 body .ui-wizard .ui-wizard-step-titles .ui-wizard-step-title.ui-state-highlight{
-    background:#78c2ad;
+    background:#2c6e9c;
     color:#fff
 }
 body .ui-wizard .ui-icon-arrowthick-1-w{

--- a/src/main/webapp/resources/ezcomp/login.xhtml
+++ b/src/main/webapp/resources/ezcomp/login.xhtml
@@ -9,45 +9,48 @@
         <h:form>
             <p:focus for="username"></p:focus>
             <div class="container-fluid">
-                <div class="row">
-                    <div class="col-lg-4 col-md-3 col-sm-1 p-4  text-center">
-                    </div>
+                <div class="row justify-content-center py-3">
 
-                    <div class="col-lg-4 col-md-6 col-sm-10 p-4  text-center">
-                        <div class="my-2 d-flex justify-content-center">
-                            <div class="shadow p-3">
-                                <h:graphicImage style="height: 6em; margin-right: 1em;" library="image" name="jf.png"></h:graphicImage>
+                    <div class="col-lg-4 col-md-6 col-sm-10">
+                        <div class="shadow p-4 rounded bg-white text-center">
+                            <div class="my-2 d-flex justify-content-center">
+                                <div class="shadow p-3">
+                                    <h:graphicImage style="height: 6em; margin-right: 1em;" library="image" name="jf.png"></h:graphicImage>
+                                </div>
+                                <div class="shadow p-3">
+                                    <h:graphicImage style="height: 6em;" library="image" name="slf.png"></h:graphicImage>
+                                </div>
                             </div>
-                            <div class="shadow p-3">
-                                <h:graphicImage style="height: 6em;" library="image" name="slf.png"></h:graphicImage>
+
+                            <h4 class="fw-bold">Fuel Management Information System</h4>
+                            <div class="my-2">
+                                <p:inputText id="username" placeholder="Username" required="true" requiredMessage="Username is required." autocomplete="off"
+                                             value="#{webUserController.userName}" class="form-control">
+                                </p:inputText>
+                            </div>
+                            <div class="my-2">
+                                <p:password id="password" placeholder="Password" required="true" requiredMessage="Password is required." autocomplete="off"
+                                            value="#{webUserController.password}" class="form-control"></p:password>
+                            </div>
+                            <div class="d-grid">
+                                <h:commandButton class="btn fw-bold btn-primary" value="Login"
+                                                 action="#{webUserController.login()}"></h:commandButton>
+                            </div>
+
+                            <div class="my-2">
+                                <p:messages></p:messages>
+                            </div>
+
+                            <div class="d-grid mt-2">
+                                <a href="https://docs.google.com/presentation/d/e/2PACX-1vTZVS7VcsoFmJbk3fnA_S5k9gdaLgfDn3pRZxOqag8M4Jl1p4jaK_2GLRU3AylVrimS5hZtHwYXW9H5/pub?start=false&amp;loop=true&amp;delayms=3000"
+                                   onclick="window.open(this.href, 'fmisUserManual', 'width=1200,height=800,noopener,noreferrer'); return false;"
+                                   class="btn btn-outline-primary fw-bold">
+                                    <i class="bi bi-book-half me-2"></i>View User Manual
+                                </a>
                             </div>
                         </div>
-
-
-
-
-                        <h4 class="fw-bold">Fuel Management Information System</h4>
-                        <div class="my-2">
-                            <p:inputText id="username" placeholder="Username" required="true" requiredMessage="Username is required." autocomplete="off"
-                                         value="#{webUserController.userName}" class="form-control">
-                            </p:inputText>
-                        </div>
-                        <div class="my-2">
-                            <p:password id="password" placeholder="Password" required="true" requiredMessage="Password is required." autocomplete="off"
-                                        value="#{webUserController.password}" class="form-control"></p:password>
-                        </div>
-                        <div class="d-grid">
-                            <h:commandButton class="btn fw-bold btn-primary" value="Login"
-                                             action="#{webUserController.login()}"></h:commandButton>
-                        </div>
-
-                        <div class="my-2">
-                            <p:messages></p:messages>
-                        </div>
                     </div>
 
-                    <div class="col-lg-4 col-md-3 col-sm-1 p-4  text-center">
-                    </div>
                 </div>
                 <div class="row">
                     <div class="my-2 d-flex justify-content-around">


### PR DESCRIPTION
## Summary
- Adds a "View User Manual" button on the login page that opens the published Google Slides user guide (https://docs.google.com/presentation/d/e/2PACX-1vTZVS7VcsoFmJbk3fnA_S5k9gdaLgfDn3pRZxOqag8M4Jl1p4jaK_2GLRU3AylVrimS5hZtHwYXW9H5/pub) in a new window.
- Retheme the app from the Bootswatch "Minty" teal to a health-appropriate "Clinical Blue" (#2c6e9c), covering both the vendored PrimeFaces theme and the Bootstrap primary-derived classes (buttons, navbar, links, form focus rings, pagination, dropdowns, tables).
- Fixes low-contrast text on the top navbar: theme.css hardcodes menu item text color directly on the inner span, which otherwise wins over Bootstrap's inherited `text-white`; both default and hover/active states are now restated for readability against the new blue background.

## Test plan
- [x] Verified locally against the running Payara `fmis-test` deployment via browser automation: navbar default state (white text on blue), hover state (dark text on light-gray highlight), and open Settings dropdown all render with correct contrast.
- [x] Verified the login page's "View User Manual" button opens the published presentation in a new window.
- [ ] Manual smoke test on other pages/components (buttons, tables, pagination) recommended before merge, since the recolor touches shared theme files used app-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)