### PR TITLE
Scope fuel request vehicle/driver lists to own institution; add institution filters; relax ODO validation

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
@@ -84,6 +84,8 @@ public class FuelRequestAndIssueController implements Serializable {
     private List<Bill> bills;
     private List<FuelTransaction> selectedTransactions = null;
     private FuelTransaction selected;
+    private String odoWarningMessage;
+    private boolean odoWarningAcknowledged;
 
     private FuelTransactionHistory selectedTransactionHistory;
     private List<FuelTransactionHistory> selectedTransactionHistories;
@@ -91,6 +93,7 @@ public class FuelRequestAndIssueController implements Serializable {
 
     private Institution institution;
     private Institution fuelStation;
+    private List<Institution> selectedInstitutions;
     private Vehicle vehicle;
     private WebUser webUser;
     private Date fromDate;
@@ -403,14 +406,15 @@ public class FuelRequestAndIssueController implements Serializable {
             return "";
         }
 
-        // Validation 3: ODO reading must be greater than the previous reading
+        // Validation 3: ODO reading must be greater than the previous reading.
+        // Not blocked outright - the user is warned and can confirm to proceed anyway.
         Double previousOdoReading = getPreviousOdoReading(selected.getVehicle());
-        if (previousOdoReading != null && selected.getOdoMeterReading() != null) {
-            if (selected.getOdoMeterReading() <= previousOdoReading) {
-                JsfUtil.addErrorMessage("ODO Meter Reading (" + selected.getOdoMeterReading() + ") must be greater than the previous reading (" + previousOdoReading + ")");
-                return "";
-            }
+        if (previousOdoReading != null && selected.getOdoMeterReading() != null
+                && selected.getOdoMeterReading() <= previousOdoReading && !odoWarningAcknowledged) {
+            odoWarningMessage = "ODO Meter Reading (" + selected.getOdoMeterReading() + ") is not greater than the previous reading (" + previousOdoReading + "). Do you want to continue anyway?";
+            return "";
         }
+        odoWarningMessage = null;
 
         // Validation 4: Request quantity must not exceed the vehicle type's maximum
         if (!isRequestQuantityWithinTypeLimit(selected.getVehicle(), selected.getRequestQuantity())) {
@@ -479,14 +483,15 @@ public class FuelRequestAndIssueController implements Serializable {
             return "";
         }
 
-        // Validation 3: ODO reading must be greater than the previous reading
+        // Validation 3: ODO reading must be greater than the previous reading.
+        // Not blocked outright - the user is warned and can confirm to proceed anyway.
         Double previousOdoReading = getPreviousOdoReading(selected.getVehicle());
-        if (previousOdoReading != null && selected.getOdoMeterReading() != null) {
-            if (selected.getOdoMeterReading() <= previousOdoReading) {
-                JsfUtil.addErrorMessage("ODO Meter Reading (" + selected.getOdoMeterReading() + ") must be greater than the previous reading (" + previousOdoReading + ")");
-                return "";
-            }
+        if (previousOdoReading != null && selected.getOdoMeterReading() != null
+                && selected.getOdoMeterReading() <= previousOdoReading && !odoWarningAcknowledged) {
+            odoWarningMessage = "ODO Meter Reading (" + selected.getOdoMeterReading() + ") is not greater than the previous reading (" + previousOdoReading + "). Do you want to continue anyway?";
+            return "";
         }
+        odoWarningMessage = null;
 
         // Validation 4: Request quantity must not exceed the vehicle type's maximum
         if (!isRequestQuantityWithinTypeLimit(selected.getVehicle(), selected.getRequestQuantity())) {
@@ -506,6 +511,30 @@ public class FuelRequestAndIssueController implements Serializable {
         save(selected);
         JsfUtil.addSuccessMessage("Special fuel request submitted successfully. Reference number: " + selected.getRequestReferenceNumber());
         return navigateToViewInstitutionFuelRequestToSltbDepot();
+    }
+
+    public String acknowledgeOdoWarningAndSubmitVehicleFuelRequest() {
+        odoWarningAcknowledged = true;
+        return submitVehicleFuelRequest();
+    }
+
+    public String acknowledgeOdoWarningAndSubmitSpecialVehicleFuelRequest() {
+        odoWarningAcknowledged = true;
+        return submitSpecialVehicleFuelRequest();
+    }
+
+    public String cancelOdoWarning() {
+        odoWarningMessage = null;
+        odoWarningAcknowledged = false;
+        return "";
+    }
+
+    public String getOdoWarningMessage() {
+        return odoWarningMessage;
+    }
+
+    public boolean isOdoWarningPending() {
+        return odoWarningMessage != null;
     }
 
     // ===== Fuel order validation helpers =====
@@ -833,6 +862,8 @@ public class FuelRequestAndIssueController implements Serializable {
     }
 
     public String navigateToAddVehicleFuelRequest() {
+        odoWarningMessage = null;
+        odoWarningAcknowledged = false;
         selected = new FuelTransaction();
         selected.setRequestAt(new Date());
         selected.setTransactionType(FuelTransactionType.VehicleFuelRequest);
@@ -841,11 +872,11 @@ public class FuelRequestAndIssueController implements Serializable {
         selected.setFromInstitution(webUserController.getLoggedInstitution());
         selected.setInstitution(webUserController.getLoggedInstitution());
         selected.setToInstitution(webUserController.getLoggedInstitution().getSupplyInstitution());
-        if (webUserController.getManagableVehicles().size() == 1) {
-            selected.setVehicle(webUserController.getManagableVehicles().get(0));
+        if (webUserController.getInstitutionVehicles().size() == 1) {
+            selected.setVehicle(webUserController.getInstitutionVehicles().get(0));
         }
-        if (webUserController.getManagableDrivers().size() == 1) {
-            selected.setDriver(webUserController.getManagableDrivers().get(0));
+        if (webUserController.getInstitutionDrivers().size() == 1) {
+            selected.setDriver(webUserController.getInstitutionDrivers().get(0));
         }
         return "/requests/request";
     }
@@ -969,6 +1000,8 @@ public class FuelRequestAndIssueController implements Serializable {
     }
 
     public String navigateToAddSpecialVehicleFuelRequest() {
+        odoWarningMessage = null;
+        odoWarningAcknowledged = false;
         selected = new FuelTransaction();
         selected.setRequestAt(new Date());
         selected.setTransactionType(FuelTransactionType.SpecialVehicleFuelRequest);
@@ -1102,8 +1135,17 @@ public class FuelRequestAndIssueController implements Serializable {
                 + " AND b.fromInstitution IN :institutions "
                 + " AND b.billDate BETWEEN :fromDate AND :toDate";
 
+        List<Institution> allowedInstitutions = webUserController.findAutherizedInstitutions();
+        List<Institution> requestingInstitutions;
+        if (selectedInstitutions == null || selectedInstitutions.isEmpty()) {
+            requestingInstitutions = allowedInstitutions;
+        } else {
+            requestingInstitutions = new ArrayList<>(selectedInstitutions);
+            requestingInstitutions.retainAll(allowedInstitutions);
+        }
+
         Map<String, Object> params = new HashMap<>();
-        params.put("institutions", webUserController.findAutherizedInstitutions());
+        params.put("institutions", requestingInstitutions);
         if (fuelStation != null) {
             j += " AND b.toInstitution=:fs ";
             params.put("fs", fuelStation);
@@ -1719,6 +1761,17 @@ public class FuelRequestAndIssueController implements Serializable {
 
     public void setFuelStation(Institution fuelStation) {
         this.fuelStation = fuelStation;
+    }
+
+    public List<Institution> getSelectedInstitutions() {
+        if (selectedInstitutions == null) {
+            selectedInstitutions = new ArrayList<>(webUserController.findAutherizedInstitutions());
+        }
+        return selectedInstitutions;
+    }
+
+    public void setSelectedInstitutions(List<Institution> selectedInstitutions) {
+        this.selectedInstitutions = selectedInstitutions;
     }
 
     @FacesConverter(forClass = FuelTransaction.class)

--- a/src/main/java/lk/gov/health/phsp/bean/ReportController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/ReportController.java
@@ -125,6 +125,7 @@ public class ReportController implements Serializable {
     private Institution institution;
     private Institution fromInstitution;
     private Institution toInstitution;
+    private List<Institution> selectedInstitutions;
     private Bill bill;
     private List<FuelTransaction> billTransactions;
     private Area area;
@@ -508,8 +509,15 @@ public class ReportController implements Serializable {
             transactionLights = new ArrayList<>();
             return;
         }
+        List<Institution> requestingInstitutions;
+        if (selectedInstitutions == null || selectedInstitutions.isEmpty()) {
+            requestingInstitutions = allowedInstitutions;
+        } else {
+            requestingInstitutions = new ArrayList<>(selectedInstitutions);
+            requestingInstitutions.retainAll(allowedInstitutions);
+        }
         List<Institution> fuelStations = toInstitution != null ? Arrays.asList(toInstitution) : null;
-        transactionLights = fillFuelTransactions(allowedInstitutions, fuelStations, getFromDate(), getToDate(), vehicleType, vehiclePurpose, driver, institutionType);
+        transactionLights = fillFuelTransactions(requestingInstitutions, fuelStations, getFromDate(), getToDate(), vehicleType, vehiclePurpose, driver, institutionType);
     }
 
     public void fillAllInstitutionFuelTransactionsDetailes() {
@@ -1746,6 +1754,17 @@ public class ReportController implements Serializable {
 
     public void setToInstitution(Institution toInstitution) {
         this.toInstitution = toInstitution;
+    }
+
+    public List<Institution> getSelectedInstitutions() {
+        if (selectedInstitutions == null) {
+            selectedInstitutions = new ArrayList<>(webUserController.findAutherizedInstitutions());
+        }
+        return selectedInstitutions;
+    }
+
+    public void setSelectedInstitutions(List<Institution> selectedInstitutions) {
+        this.selectedInstitutions = selectedInstitutions;
     }
 
     public List<FuelTransactionLight> getTransactionLights() {

--- a/src/main/java/lk/gov/health/phsp/bean/WebUserController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/WebUserController.java
@@ -111,7 +111,9 @@ public class WebUserController implements Serializable {
     private List<WebUser> managableUsers;
     private List<Institution> loggableInstitutions;
     private List<Vehicle> managableVehicles;
+    private List<Vehicle> institutionVehicles;
     private List<Driver> managableDrivers;
+    private List<Driver> institutionDrivers;
 
     private WebUserRole userRole;
 
@@ -713,7 +715,9 @@ public class WebUserController implements Serializable {
     public String login() {
         loggableInstitutions = null;
         managableVehicles = null;
+        institutionVehicles = null;
         managableDrivers = null;
+        institutionDrivers = null;
         if (userName == null || userName.trim().equals("")) {
             JsfUtil.addErrorMessage("Please enter a Username");
             return "";
@@ -741,7 +745,9 @@ public class WebUserController implements Serializable {
         loggableInstitutions = institutionApplicationController.findChildrenInstitutions(loggedInstitution);
         loggableInstitutions.add(loggedInstitution);
         managableVehicles = vehicleApplicationController.findVehiclesByInstitutions(loggableInstitutions);
+        institutionVehicles = vehicleApplicationController.findVehiclesByInstitution(loggedInstitution);
         managableDrivers = driverApplicationController.findDriversByInstitutions(loggableInstitutions);
+        institutionDrivers = driverApplicationController.findDriversByInstitution(loggedInstitution);
         managableUsers = findManagableUsers();
 
         Calendar c = Calendar.getInstance();
@@ -2063,6 +2069,13 @@ public class WebUserController implements Serializable {
         return loggableInstitutions;
     }
 
+    public boolean isHasChildInstitutions() {
+        if (loggedInstitution == null) {
+            return false;
+        }
+        return !institutionApplicationController.findChildrenInstitutions(loggedInstitution).isEmpty();
+    }
+
     public void setLoggableInstitutions(List<Institution> loggableInstitutions) {
         this.loggableInstitutions = loggableInstitutions;
     }
@@ -2241,12 +2254,34 @@ public class WebUserController implements Serializable {
         this.managableVehicles = managableVehicles;
     }
 
+    public List<Vehicle> getInstitutionVehicles() {
+        if (institutionVehicles == null) {
+            institutionVehicles = new ArrayList<>();
+        }
+        return institutionVehicles;
+    }
+
+    public void setInstitutionVehicles(List<Vehicle> institutionVehicles) {
+        this.institutionVehicles = institutionVehicles;
+    }
+
     public List<Driver> getManagableDrivers() {
         return managableDrivers;
     }
 
     public void setManagableDrivers(List<Driver> managableDrivers) {
         this.managableDrivers = managableDrivers;
+    }
+
+    public List<Driver> getInstitutionDrivers() {
+        if (institutionDrivers == null) {
+            institutionDrivers = new ArrayList<>();
+        }
+        return institutionDrivers;
+    }
+
+    public void setInstitutionDrivers(List<Driver> institutionDrivers) {
+        this.institutionDrivers = institutionDrivers;
     }
 
     @FacesConverter(forClass = WebUser.class)

--- a/src/main/java/lk/gov/health/phsp/enums/VehicleType.java
+++ b/src/main/java/lk/gov/health/phsp/enums/VehicleType.java
@@ -17,9 +17,9 @@ public enum VehicleType {
     Cab("Cab", true, "rgba(75, 192, 192, 0.6)", 80.0),
     Car("Car", true, "rgba(153, 102, 255, 0.6)", 50.0),
     FoggingMachine("Fogging Machine", false, "rgba(255, 159, 64, 0.6)", 40.0),
-    Generator("Generator", false, "rgba(199, 199, 199, 0.6)", 100.0), // Example of a lighter shade for non-vehicle items
+    Generator("Generator", false, "rgba(199, 199, 199, 0.6)", 350.0), // Example of a lighter shade for non-vehicle items
     GullyBowser("Gully Bowser", true, "rgba(255, 129, 102, 0.6)", 100.0),
-    Incinerator("Incinerator", false, "rgba(220, 20, 60, 0.6)", 500.0),
+    Incinerator("Incinerator", false, "rgba(220, 20, 60, 0.6)", 1000.0),
     ServiceStation("Service Station", false, "rgba(200, 60, 60, 0.6)", null), // no limit
     Jeep("Jeep", true, "rgba(0, 255, 255, 0.6)", 110.0),
     Lorry("Lorry", true, "rgba(0, 0, 128, 0.6)", 300.0),

--- a/src/main/webapp/reports/cpc_head_office/list.xhtml
+++ b/src/main/webapp/reports/cpc_head_office/list.xhtml
@@ -136,6 +136,22 @@
                             <h:outputText value="#{transaction.issueReferenceNumber}" />
                         </p:column>
 
+                        <p:column headerText="Payment Submission" sortBy="#{transaction.submittedForPayment}" filterBy="#{transaction.submittedForPayment}">
+                            <p:commandLink
+                                ajax="false"
+                                action="#{reportController.navigateToViewRequest()}"
+                                title="View request">
+                                <f:setPropertyActionListener value="#{transaction}" target="#{reportController.fuelTransactionLight}" >
+                                </f:setPropertyActionListener>
+                                <h:outputText value="Submitted for Payment" styleClass="badge bg-success text-wrap" rendered="#{transaction.submittedForPayment}" />
+                                <h:outputText value="Not Submitted" styleClass="badge bg-secondary text-wrap" rendered="#{!transaction.submittedForPayment}" />
+                            </p:commandLink>
+                        </p:column>
+
+                        <p:column headerText="Submitted On" sortBy="#{transaction.submittedToPaymentAt}" filterBy="#{transaction.submittedToPaymentAt}" filterMatchMode="numeric">
+                            <h:outputText value="#{transaction.formattedSubmittedToPaymentAt}" />
+                        </p:column>
+
                     </p:dataTable>
 
 

--- a/src/main/webapp/reports/list_institution.xhtml
+++ b/src/main/webapp/reports/list_institution.xhtml
@@ -36,6 +36,20 @@
                                 itemLabel="#{fs.name}"
                                 itemValue="#{fs}"
                                 ></p:autoComplete>
+
+                            <p:outputLabel value="Institution" rendered="#{webUserController.hasChildInstitutions}" />
+                            <p:selectCheckboxMenu
+                                value="#{reportController.selectedInstitutions}"
+                                label="Institutions"
+                                filter="true"
+                                filterMatchMode="contains"
+                                multiple="true"
+                                rendered="#{webUserController.hasChildInstitutions}" >
+                                <f:selectItems value="#{webUserController.loggableInstitutions}" var="ins" itemLabel="#{ins.name}" itemValue="#{ins}" />
+                            </p:selectCheckboxMenu>
+
+                            <p:outputLabel value="Institution" rendered="#{!webUserController.hasChildInstitutions}" />
+                            <p:outputLabel value="#{webUserController.loggedInstitution.name}" rendered="#{!webUserController.hasChildInstitutions}" />
                         </p:panelGrid>
                         <p:panelGrid columns="2" >
                             <h:outputLabel value="Type:" for="vehicleType" />

--- a/src/main/webapp/reports/list_to_paid_institution.xhtml
+++ b/src/main/webapp/reports/list_to_paid_institution.xhtml
@@ -59,6 +59,23 @@
                                                 class="w-100 m-1"
                                                 inputStyleClass="w-100"></p:autoComplete>
                                         </div>
+                                        <div class="form-group" rendered="#{webUserController.hasChildInstitutions}">
+                                            <label for="selInstitutions" class="d-block">Institution</label>
+                                            <p:selectCheckboxMenu
+                                                id="selInstitutions"
+                                                value="#{fuelRequestAndIssueController.selectedInstitutions}"
+                                                label="Institutions"
+                                                filter="true"
+                                                filterMatchMode="contains"
+                                                multiple="true"
+                                                class="w-100 m-1" >
+                                                <f:selectItems value="#{webUserController.loggableInstitutions}" var="ins" itemLabel="#{ins.name}" itemValue="#{ins}" />
+                                            </p:selectCheckboxMenu>
+                                        </div>
+                                        <div class="form-group" rendered="#{!webUserController.hasChildInstitutions}">
+                                            <label class="d-block">Institution</label>
+                                            <p:outputLabel value="#{webUserController.loggedInstitution.name}" />
+                                        </div>
                                         <div class="form-group d-flex justify-content-center">
                                             <p:commandButton value="List Requests"
                                                              action="#{fuelRequestAndIssueController.listPaymentBillsForInstitutionLevel()}"

--- a/src/main/webapp/requests/request.xhtml
+++ b/src/main/webapp/requests/request.xhtml
@@ -50,7 +50,7 @@
                                         filter="true" 
                                         rendered="#{fuelRequestAndIssueController.selected.vehicle eq null}" filterMatchMode="contains" required="true" requiredMessage="You must select a vehicle" styleClass="w-100">
                                         <f:selectItem itemLabel="Select a vehicle" noSelectionOption="true" />
-                                        <f:selectItems value="#{webUserController.managableVehicles}" var="v" itemLabel="#{v.vehicleNumber}" itemValue="#{v}" />
+                                        <f:selectItems value="#{webUserController.institutionVehicles}" var="v" itemLabel="#{v.vehicleNumber}" itemValue="#{v}" />
                                     </p:selectOneMenu>
 
                                     <p:outputLabel for="acDriver" value="Driver" />
@@ -64,7 +64,7 @@
                                                      requiredMessage="You must select a driver" 
                                                      styleClass="w-100">
                                         <f:selectItem itemLabel="Select a driver" noSelectionOption="true" />
-                                        <f:selectItems value="#{webUserController.managableDrivers}" var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                        <f:selectItems value="#{webUserController.institutionDrivers}" var="d" itemLabel="#{d.name}" itemValue="#{d}" />
                                     </p:selectOneMenu>
 
                                     <p:outputLabel value="Depot / Fuel Station" />
@@ -189,6 +189,33 @@
                                                              onclick="PF('confirmDialog').hide();" />
                                         </div>
                                     </h:panelGroup>
+                                </p:dialog>
+
+                                <!-- ODO warning dialog: shown instead of blocking submission outright -->
+                                <p:dialog header="ODO Meter Reading Warning"
+                                          widgetVar="odoWarningDialog"
+                                          modal="true"
+                                          closable="false"
+                                          responsive="true"
+                                          visible="#{fuelRequestAndIssueController.odoWarningPending}">
+                                    <div class="p-3">
+                                        <p class="text-danger">
+                                            <i class="pi pi-exclamation-triangle" />
+                                            <h:outputText value=" #{fuelRequestAndIssueController.odoWarningMessage}" />
+                                        </p>
+                                    </div>
+                                    <div class="text-center mt-3 mb-3">
+                                        <p:commandButton value="Continue Anyway"
+                                                         icon="pi pi-check"
+                                                         styleClass="ui-button-raised ui-button-warning mx-1"
+                                                         action="#{fuelRequestAndIssueController.acknowledgeOdoWarningAndSubmitVehicleFuelRequest}"
+                                                         ajax="false" />
+                                        <p:commandButton value="Go Back and Edit"
+                                                         icon="pi pi-times"
+                                                         styleClass="ui-button-raised ui-button-secondary mx-1"
+                                                         action="#{fuelRequestAndIssueController.cancelOdoWarning}"
+                                                         ajax="false" />
+                                    </div>
                                 </p:dialog>
 
                             </div>

--- a/src/main/webapp/requests/request_edit.xhtml
+++ b/src/main/webapp/requests/request_edit.xhtml
@@ -40,14 +40,14 @@
                                         class="w-100"
                                         id="acVehicle" value="#{fuelRequestAndIssueController.selected.vehicle}" filter="true" rendered="#{fuelRequestAndIssueController.selected.vehicle eq null}" filterMatchMode="contains" required="true" requiredMessage="You must select a vehicle" styleClass="w-100">
                                         <f:selectItem itemLabel="Select a vehicle" noSelectionOption="true" />
-                                        <f:selectItems value="#{webUserController.managableVehicles}" var="v" itemLabel="#{v.vehicleNumber}" itemValue="#{v}" />
+                                        <f:selectItems value="#{webUserController.institutionVehicles}" var="v" itemLabel="#{v.vehicleNumber}" itemValue="#{v}" />
                                     </p:selectOneMenu>
 
                                     <p:outputLabel for="acDriver" value="Driver" />
                                     <p:inputText readonly="true" class="w-100" value="#{fuelRequestAndIssueController.selected.driver.name}" rendered="#{fuelRequestAndIssueController.selected.driver ne null}" />
                                     <p:selectOneMenu id="acDriver" value="#{fuelRequestAndIssueController.selected.driver}" filter="true" rendered="#{fuelRequestAndIssueController.selected.driver eq null}" filterMatchMode="contains" required="true" requiredMessage="You must select a driver" styleClass="w-100">
                                         <f:selectItem itemLabel="Select a driver" noSelectionOption="true" />
-                                        <f:selectItems value="#{webUserController.managableDrivers}" var="d" itemLabel="#{d.name}" itemValue="#{d}" />
+                                        <f:selectItems value="#{webUserController.institutionDrivers}" var="d" itemLabel="#{d.name}" itemValue="#{d}" />
                                     </p:selectOneMenu>
 
                                     <p:outputLabel value="Depot / Fuel Station" />
@@ -102,6 +102,32 @@
                                         value="#{fuelRequestAndIssueController.selected.comments}" />
                                 </p:panelGrid>
 
+                                <!-- ODO warning dialog: shown instead of blocking submission outright -->
+                                <p:dialog header="ODO Meter Reading Warning"
+                                          widgetVar="odoWarningDialog"
+                                          modal="true"
+                                          closable="false"
+                                          responsive="true"
+                                          visible="#{fuelRequestAndIssueController.odoWarningPending}">
+                                    <div class="p-3">
+                                        <p class="text-danger">
+                                            <i class="pi pi-exclamation-triangle" />
+                                            <h:outputText value=" #{fuelRequestAndIssueController.odoWarningMessage}" />
+                                        </p>
+                                    </div>
+                                    <div class="text-center mt-3 mb-3">
+                                        <p:commandButton value="Continue Anyway"
+                                                         icon="pi pi-check"
+                                                         styleClass="ui-button-raised ui-button-warning mx-1"
+                                                         action="#{fuelRequestAndIssueController.acknowledgeOdoWarningAndSubmitVehicleFuelRequest}"
+                                                         ajax="false" />
+                                        <p:commandButton value="Go Back and Edit"
+                                                         icon="pi pi-times"
+                                                         styleClass="ui-button-raised ui-button-secondary mx-1"
+                                                         action="#{fuelRequestAndIssueController.cancelOdoWarning}"
+                                                         ajax="false" />
+                                    </div>
+                                </p:dialog>
 
                             </div>
                         </div>

--- a/src/main/webapp/requests/special_request.xhtml
+++ b/src/main/webapp/requests/special_request.xhtml
@@ -130,7 +130,7 @@
                                     <p:inputNumber
                                         id="txtQty"
                                         minValue="0"
-                                        decimalPlaces="1"
+                                        decimalPlaces="2"
                                         inputStyleClass="form-control"
                                         required="true"
                                         requiredMessage="Quantity is required"
@@ -171,6 +171,32 @@
 
                                 </p:panelGrid>
 
+                                <!-- ODO warning dialog: shown instead of blocking submission outright -->
+                                <p:dialog header="ODO Meter Reading Warning"
+                                          widgetVar="odoWarningDialog"
+                                          modal="true"
+                                          closable="false"
+                                          responsive="true"
+                                          visible="#{fuelRequestAndIssueController.odoWarningPending}">
+                                    <div class="p-3">
+                                        <p class="text-danger">
+                                            <i class="pi pi-exclamation-triangle" />
+                                            <h:outputText value=" #{fuelRequestAndIssueController.odoWarningMessage}" />
+                                        </p>
+                                    </div>
+                                    <div class="text-center mt-3 mb-3">
+                                        <p:commandButton value="Continue Anyway"
+                                                         icon="pi pi-check"
+                                                         styleClass="ui-button-raised ui-button-warning mx-1"
+                                                         action="#{fuelRequestAndIssueController.acknowledgeOdoWarningAndSubmitSpecialVehicleFuelRequest}"
+                                                         ajax="false" />
+                                        <p:commandButton value="Go Back and Edit"
+                                                         icon="pi pi-times"
+                                                         styleClass="ui-button-raised ui-button-secondary mx-1"
+                                                         action="#{fuelRequestAndIssueController.cancelOdoWarning}"
+                                                         ajax="false" />
+                                    </div>
+                                </p:dialog>
 
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- Vehicle/driver dropdowns on normal fuel request pages (`request.xhtml`, `request_edit.xhtml`) now list only the logged-in institution's own vehicles/drivers (new `WebUserController.institutionVehicles` / `institutionDrivers`), fixing a regression where they were pulling in child-institution vehicles/drivers through the shared `managableVehicles`/`managableDrivers` lists used by the admin (own+children) views.
- `list_institution.xhtml` and `list_to_paid_institution.xhtml` gain an institution multi-select (defaults to all) when the logged institution has children; otherwise the filter is fixed to the own institution.
- ODO meter reading no longer blocks fuel request submission outright when it isn't greater than the previous reading — it now shows a confirmation dialog with the details and lets the user proceed or go back and edit.
- `special_request.xhtml` quantity field now allows 2 decimal places to match `request.xhtml` (was limited to 1).
- Generator and Incinerator max request quantities raised to 350 and 1000 liters respectively.
- `cpc_head_office/list.xhtml` report gains the Payment Submission and Submitted On columns already present on `list_institution.xhtml`.

## Test plan
- [ ] Log in as an institution-level user whose institution has child institutions; confirm the vehicle/driver dropdowns on `request.xhtml` and `request_edit.xhtml` show only that institution's own vehicles/drivers, while `institution/admin/vehicle_list.xhtml` and `driver_list.xhtml` still show own+children.
- [ ] On `list_institution.xhtml` and `list_to_paid_institution.xhtml`, confirm the institution selector appears only when there are child institutions, and filtering by a subset works.
- [ ] Submit a vehicle fuel request with an ODO reading not greater than the previous one; confirm a dialog appears instead of a blocking error, and both "Continue Anyway" and "Go Back and Edit" work as expected.
- [ ] Confirm quantity on `special_request.xhtml` accepts 2 decimal places.
- [ ] Confirm Generator/Incinerator requests up to 350/1000 liters are accepted.
- [ ] Confirm `cpc_head_office/list.xhtml` shows Payment Submission and Submitted On columns with correct data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)