### PR TITLE
Single-select institution filter for reports; uppercase fuel request reference numbers

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
@@ -5,6 +5,7 @@ import lk.gov.health.phsp.facade.FuelTransactionHistoryFacade;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Calendar;
@@ -93,7 +94,7 @@ public class FuelRequestAndIssueController implements Serializable {
 
     private Institution institution;
     private Institution fuelStation;
-    private List<Institution> selectedInstitutions;
+    private Institution selectedInstitution;
     private Vehicle vehicle;
     private WebUser webUser;
     private Date fromDate;
@@ -385,6 +386,7 @@ public class FuelRequestAndIssueController implements Serializable {
             JsfUtil.addErrorMessage("Enter a referance number");
             return "";
         }
+        selected.setRequestReferenceNumber(selected.getRequestReferenceNumber().trim().toUpperCase());
         if (selected.getOdoMeterReading() == null) {
             JsfUtil.addErrorMessage("ODO Meter Reading is required");
             return "";
@@ -462,6 +464,7 @@ public class FuelRequestAndIssueController implements Serializable {
             JsfUtil.addErrorMessage("Enter a referance number");
             return "";
         }
+        selected.setRequestReferenceNumber(selected.getRequestReferenceNumber().trim().toUpperCase());
         if (selected.getOdoMeterReading() == null) {
             JsfUtil.addErrorMessage("ODO Meter Reading is required");
             return "";
@@ -1137,11 +1140,10 @@ public class FuelRequestAndIssueController implements Serializable {
 
         List<Institution> allowedInstitutions = webUserController.findAutherizedInstitutions();
         List<Institution> requestingInstitutions;
-        if (selectedInstitutions == null || selectedInstitutions.isEmpty()) {
+        if (selectedInstitution == null || !allowedInstitutions.contains(selectedInstitution)) {
             requestingInstitutions = allowedInstitutions;
         } else {
-            requestingInstitutions = new ArrayList<>(selectedInstitutions);
-            requestingInstitutions.retainAll(allowedInstitutions);
+            requestingInstitutions = Arrays.asList(selectedInstitution);
         }
 
         Map<String, Object> params = new HashMap<>();
@@ -1763,15 +1765,12 @@ public class FuelRequestAndIssueController implements Serializable {
         this.fuelStation = fuelStation;
     }
 
-    public List<Institution> getSelectedInstitutions() {
-        if (selectedInstitutions == null) {
-            selectedInstitutions = new ArrayList<>(webUserController.findAutherizedInstitutions());
-        }
-        return selectedInstitutions;
+    public Institution getSelectedInstitution() {
+        return selectedInstitution;
     }
 
-    public void setSelectedInstitutions(List<Institution> selectedInstitutions) {
-        this.selectedInstitutions = selectedInstitutions;
+    public void setSelectedInstitution(Institution selectedInstitution) {
+        this.selectedInstitution = selectedInstitution;
     }
 
     @FacesConverter(forClass = FuelTransaction.class)

--- a/src/main/java/lk/gov/health/phsp/bean/ReportController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/ReportController.java
@@ -125,7 +125,7 @@ public class ReportController implements Serializable {
     private Institution institution;
     private Institution fromInstitution;
     private Institution toInstitution;
-    private List<Institution> selectedInstitutions;
+    private Institution selectedInstitution;
     private Bill bill;
     private List<FuelTransaction> billTransactions;
     private Area area;
@@ -510,11 +510,10 @@ public class ReportController implements Serializable {
             return;
         }
         List<Institution> requestingInstitutions;
-        if (selectedInstitutions == null || selectedInstitutions.isEmpty()) {
+        if (selectedInstitution == null || !allowedInstitutions.contains(selectedInstitution)) {
             requestingInstitutions = allowedInstitutions;
         } else {
-            requestingInstitutions = new ArrayList<>(selectedInstitutions);
-            requestingInstitutions.retainAll(allowedInstitutions);
+            requestingInstitutions = Arrays.asList(selectedInstitution);
         }
         List<Institution> fuelStations = toInstitution != null ? Arrays.asList(toInstitution) : null;
         transactionLights = fillFuelTransactions(requestingInstitutions, fuelStations, getFromDate(), getToDate(), vehicleType, vehiclePurpose, driver, institutionType);
@@ -1756,15 +1755,12 @@ public class ReportController implements Serializable {
         this.toInstitution = toInstitution;
     }
 
-    public List<Institution> getSelectedInstitutions() {
-        if (selectedInstitutions == null) {
-            selectedInstitutions = new ArrayList<>(webUserController.findAutherizedInstitutions());
-        }
-        return selectedInstitutions;
+    public Institution getSelectedInstitution() {
+        return selectedInstitution;
     }
 
-    public void setSelectedInstitutions(List<Institution> selectedInstitutions) {
-        this.selectedInstitutions = selectedInstitutions;
+    public void setSelectedInstitution(Institution selectedInstitution) {
+        this.selectedInstitution = selectedInstitution;
     }
 
     public List<FuelTransactionLight> getTransactionLights() {

--- a/src/main/webapp/reports/list_institution.xhtml
+++ b/src/main/webapp/reports/list_institution.xhtml
@@ -38,15 +38,14 @@
                                 ></p:autoComplete>
 
                             <p:outputLabel value="Institution" rendered="#{webUserController.hasChildInstitutions}" />
-                            <p:selectCheckboxMenu
-                                value="#{reportController.selectedInstitutions}"
-                                label="Institutions"
+                            <p:selectOneMenu
+                                value="#{reportController.selectedInstitution}"
                                 filter="true"
                                 filterMatchMode="contains"
-                                multiple="true"
                                 rendered="#{webUserController.hasChildInstitutions}" >
+                                <f:selectItem itemLabel="-- Own Institution and All Child Institutions --" noSelectionOption="true" />
                                 <f:selectItems value="#{webUserController.loggableInstitutions}" var="ins" itemLabel="#{ins.name}" itemValue="#{ins}" />
-                            </p:selectCheckboxMenu>
+                            </p:selectOneMenu>
 
                             <p:outputLabel value="Institution" rendered="#{!webUserController.hasChildInstitutions}" />
                             <p:outputLabel value="#{webUserController.loggedInstitution.name}" rendered="#{!webUserController.hasChildInstitutions}" />

--- a/src/main/webapp/reports/list_to_paid_institution.xhtml
+++ b/src/main/webapp/reports/list_to_paid_institution.xhtml
@@ -61,16 +61,15 @@
                                         </div>
                                         <div class="form-group" rendered="#{webUserController.hasChildInstitutions}">
                                             <label for="selInstitutions" class="d-block">Institution</label>
-                                            <p:selectCheckboxMenu
+                                            <p:selectOneMenu
                                                 id="selInstitutions"
-                                                value="#{fuelRequestAndIssueController.selectedInstitutions}"
-                                                label="Institutions"
+                                                value="#{fuelRequestAndIssueController.selectedInstitution}"
                                                 filter="true"
                                                 filterMatchMode="contains"
-                                                multiple="true"
                                                 class="w-100 m-1" >
+                                                <f:selectItem itemLabel="-- Own Institution and All Child Institutions --" noSelectionOption="true" />
                                                 <f:selectItems value="#{webUserController.loggableInstitutions}" var="ins" itemLabel="#{ins.name}" itemValue="#{ins}" />
-                                            </p:selectCheckboxMenu>
+                                            </p:selectOneMenu>
                                         </div>
                                         <div class="form-group" rendered="#{!webUserController.hasChildInstitutions}">
                                             <label class="d-block">Institution</label>


### PR DESCRIPTION
## Summary
- The institution filter added to `list_institution.xhtml` and `list_to_paid_institution.xhtml` in #139 was a multi-select checkbox menu; changed it to a single `p:selectOneMenu` per feedback: no selection means own institution + all child institutions, or the user picks exactly one authorized institution to narrow to.
- Fuel request reference numbers on both the normal (`request.xhtml`/`request_edit.xhtml`) and special (`special_request.xhtml`) vehicle fuel request forms are now always normalized to upper case server-side (trimmed) before validation and save, regardless of how the user typed them.

## Test plan
- [ ] On `list_institution.xhtml` and `list_to_paid_institution.xhtml`, confirm the institution filter is a single dropdown; leaving it unselected includes own + all child institutions, and picking one institution restricts to just that one.
- [ ] Submit a vehicle fuel request (and a special vehicle fuel request) with a lowercase/mixed-case reference number; confirm it's saved and displayed in upper case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)