### PR TITLE
Include logged institution's drivers in special vehicle fuel request driver list

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/DriverController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/DriverController.java
@@ -270,6 +270,26 @@ public class DriverController implements Serializable {
         return insDrivers;
     }
 
+    /**
+     * Drivers of the given (e.g. special request vehicle's) institution, plus drivers of the
+     * logged-in user's own institution - since a special vehicle can be driven by a driver from
+     * the requesting institution rather than the vehicle's home institution.
+     */
+    public List<Driver> institutionAndLoggedInstitutionDrivers(Institution vehicleInstitution) {
+        List<Institution> institutions = new ArrayList<>();
+        if (vehicleInstitution != null) {
+            institutions.add(vehicleInstitution);
+        }
+        Institution loggedInstitution = webUserController.getLoggedInstitution();
+        if (loggedInstitution != null && !institutions.contains(loggedInstitution)) {
+            institutions.add(loggedInstitution);
+        }
+        if (institutions.isEmpty()) {
+            return new ArrayList<>();
+        }
+        return driverApplicationController.findDriversByInstitutions(institutions);
+    }
+
     public String saveOrUpdateDriver() {
         if (selected == null) {
             JsfUtil.addErrorMessage("Nothing to select");

--- a/src/main/webapp/requests/special_request.xhtml
+++ b/src/main/webapp/requests/special_request.xhtml
@@ -87,7 +87,7 @@
                                         requiredMessage="You must select a driver"
                                         styleClass="form-control w-100">
                                         <f:selectItem itemLabel="Select a driver"  />
-                                        <f:selectItems value="#{driverController.institutionDrivers(fuelRequestAndIssueController.selected.vehicle.institution)}" var="d"
+                                        <f:selectItems value="#{driverController.institutionAndLoggedInstitutionDrivers(fuelRequestAndIssueController.selected.vehicle.institution)}" var="d"
                                                        itemLabel="#{d.name}" itemValue="#{d}" />
                                     </p:selectOneMenu>
 


### PR DESCRIPTION
## Summary
- Special vehicle fuel requests let a user pick a vehicle from any institution (`vehicleController.completeVehiclesByWords`), but the driver dropdown (`special_request.xhtml`) only listed drivers from that vehicle's home institution via `DriverController.institutionDrivers(...)`, excluding the requesting (logged-in) institution's own drivers.
- Added `DriverController.institutionAndLoggedInstitutionDrivers(Institution vehicleInstitution)`, which unions the vehicle's institution with `webUserController.getLoggedInstitution()` (deduped) before querying drivers, and wired `special_request.xhtml` to use it.

## Test plan
- [ ] As an institution-level user, open Special Vehicle Fuel Request, select a vehicle belonging to a different institution, and confirm the driver dropdown includes both that vehicle's institution's drivers and your own institution's drivers.
- [ ] Select a vehicle belonging to your own institution and confirm the driver list is unchanged (no duplicates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)