### PR TITLE
Add blank Reason for Reprint field on reprinted payment requests

### DIFF
--- a/src/main/webapp/requests/list_payment.xhtml
+++ b/src/main/webapp/requests/list_payment.xhtml
@@ -168,6 +168,8 @@
                                                             <f:convertDateTime pattern="HH:mm:ss"/>
                                                         </h:outputText>
                                                     </h:panelGroup>
+                                                    <h:outputText value="Reason for Reprint:" rendered="#{fuelRequestAndIssueController.paymentRequestReprint}"/>
+                                                    <h:outputText value="" rendered="#{fuelRequestAndIssueController.paymentRequestReprint}"/>
                                                 </p:panelGrid>
 
                                                 <!-- Transactions Table -->


### PR DESCRIPTION
## Summary
- `list_payment.xhtml`'s Bill Information table now has a "Reason for Reprint:" row directly below "Requested Date & Time:", with the right (value) column left blank for staff to hand-write the reason on the printed page.
- Only shown when `fuelRequestAndIssueController.paymentRequestReprint` is true (the same flag that gates the existing "REPRINT" banner) — i.e. only when the page is reached via the View button on `list_to_paid_institution.xhtml`, not on the original print right after `makePaymentRequest()`.

## Test plan
- [ ] From `list_to_paid_institution.xhtml`, click View on a payment request; confirm the printed/preview page shows both the "REPRINT" banner and the blank "Reason for Reprint:" row.
- [ ] Submit a new payment request through the normal flow (`makePaymentRequest`) and confirm the resulting print page shows neither the REPRINT banner nor the Reason for Reprint row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)