### PR TITLE
Exclude retired requests from reference number duplicate check

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
@@ -561,12 +561,14 @@ public class FuelRequestAndIssueController implements Serializable {
         Date nextMonthStart = cal.getTime();
 
         // Count orders with the same reference number in the same calendar month for this
-        // institution, including active AND inactive (retired/cancelled/rejected) orders.
+        // institution, excluding retired (deleted) orders so a reference number freed up
+        // by deleting a request can be reused.
         String jpql = "SELECT COUNT(ft) FROM FuelTransaction ft "
                 + "WHERE ft.requestReferenceNumber = :refNum "
                 + "AND ft.fromInstitution = :institution "
                 + "AND ft.requestedDate >= :monthStart "
-                + "AND ft.requestedDate < :nextMonthStart";
+                + "AND ft.requestedDate < :nextMonthStart "
+                + "AND ft.retired = false";
 
         Map<String, Object> params = new HashMap<>();
         params.put("refNum", referenceNumber.trim());


### PR DESCRIPTION
## Summary
- Fixes #143: deleting a fuel request (or special vehicle fuel request) soft-deletes it by setting `retired = true`, but the reference-number-uniqueness check in `FuelRequestAndIssueController.isReferenceNumberUnique()` still counted retired records, so a reference number used on a deleted request could never be reused.
- Adds `AND ft.retired = false` to the duplicate-check JPQL, matching the existing convention used elsewhere in this file (e.g. `getPreviousOdoReading`, `findFuelTransactions`).
- Both regular vehicle fuel requests and special vehicle fuel requests share this single validation method, so one fix covers both flows.

## Test plan
- [ ] Create a fuel request with reference number `X` for an institution.
- [ ] Delete that request (admin-approved delete flow, sets `retired = true`).
- [ ] Create a new fuel request with the same reference number `X` for the same institution/month — should now succeed instead of being blocked.
- [ ] Create a fuel request with reference number `Y`, do NOT delete it, then attempt another request with reference number `Y` in the same institution/month — should still be blocked as before.
- [ ] Repeat the above two checks for a special vehicle fuel request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)