### PR TITLE
Add Payment Submission status columns to cpc and institution report lists

### DIFF
--- a/src/main/webapp/institution/reports/list.xhtml
+++ b/src/main/webapp/institution/reports/list.xhtml
@@ -146,6 +146,22 @@
                             <h:outputText value="#{transaction.issueReferenceNumber}" />
                         </p:column>
 
+                        <p:column headerText="Payment Submission" sortBy="#{transaction.submittedForPayment}" filterBy="#{transaction.submittedForPayment}">
+                            <p:commandLink
+                                ajax="false"
+                                action="#{reportController.navigateToViewRequest()}"
+                                title="View request">
+                                <f:setPropertyActionListener value="#{transaction}" target="#{reportController.fuelTransactionLight}" >
+                                </f:setPropertyActionListener>
+                                <h:outputText value="Submitted for Payment" styleClass="badge bg-success text-wrap" rendered="#{transaction.submittedForPayment}" />
+                                <h:outputText value="Not Submitted" styleClass="badge bg-secondary text-wrap" rendered="#{!transaction.submittedForPayment}" />
+                            </p:commandLink>
+                        </p:column>
+
+                        <p:column headerText="Submitted On" sortBy="#{transaction.submittedToPaymentAt}" filterBy="#{transaction.submittedToPaymentAt}" filterMatchMode="numeric">
+                            <h:outputText value="#{transaction.formattedSubmittedToPaymentAt}" />
+                        </p:column>
+
                     </p:dataTable>
 
 

--- a/src/main/webapp/reports/cpc/list.xhtml
+++ b/src/main/webapp/reports/cpc/list.xhtml
@@ -116,6 +116,22 @@
                             <h:outputText value="#{transaction.issueReferenceNumber}" />
                         </p:column>
 
+                        <p:column headerText="Payment Submission" sortBy="#{transaction.submittedForPayment}" filterBy="#{transaction.submittedForPayment}">
+                            <p:commandLink
+                                ajax="false"
+                                action="#{reportController.navigateToViewRequest()}"
+                                title="View request">
+                                <f:setPropertyActionListener value="#{transaction}" target="#{reportController.fuelTransactionLight}" >
+                                </f:setPropertyActionListener>
+                                <h:outputText value="Submitted for Payment" styleClass="badge bg-success text-wrap" rendered="#{transaction.submittedForPayment}" />
+                                <h:outputText value="Not Submitted" styleClass="badge bg-secondary text-wrap" rendered="#{!transaction.submittedForPayment}" />
+                            </p:commandLink>
+                        </p:column>
+
+                        <p:column headerText="Submitted On" sortBy="#{transaction.submittedToPaymentAt}" filterBy="#{transaction.submittedToPaymentAt}" filterMatchMode="numeric">
+                            <h:outputText value="#{transaction.formattedSubmittedToPaymentAt}" />
+                        </p:column>
+
                     </p:dataTable>
 
 


### PR DESCRIPTION
## Summary
- `reports/cpc/list.xhtml` and `institution/reports/list.xhtml` were missing the "Payment Submission" status badge and "Submitted On" date columns that were already added to `reports/cpc_head_office/list.xhtml` and `reports/list_institution.xhtml`.
- Both pages already fetch `submittedToPayment`/`submittedToPaymentAt` via the shared `ReportController.fillFuelTransactions()` query, so this is a display-only fix — no controller/backend changes needed.

## Test plan
- [ ] Load `reports/cpc/list.xhtml`, run a search, confirm "Payment Submission" and "Submitted On" columns render and the badge link navigates to the request view
- [ ] Load `institution/reports/list.xhtml`, run a search, confirm the same columns render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)