### PR TITLE
Add CI/CD workflow: auto-deploy main to production on merge

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,37 @@
+name: Deploy to production
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: fmis-production-deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, fmis-prod]
+    steps:
+      - name: Fast-forward production checkout to origin/main
+        run: |
+          set -e
+          cd /home/buddhika/NetBeansProjects/dev/fmis
+          git fetch origin main
+          git merge --ff-only origin/main
+
+      - name: Build (mvn package, in place)
+        run: |
+          set -e
+          cd /home/buddhika/NetBeansProjects/dev/fmis
+          export JAVA_HOME=/home/buddhika/jdk11
+          export PATH="$JAVA_HOME/bin:$PATH"
+          /home/buddhika/netbeans-12.4/netbeans/java/maven/bin/mvn -B package
+
+      - name: Redeploy to Payara
+        run: |
+          set -e
+          /home/buddhika/payara5/bin/asadmin deploy --force=true --name fmis --contextroot fmis /home/buddhika/NetBeansProjects/dev/fmis/target/fmis-0.1


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy-production.yml`, triggered on every push to `main` (i.e. every merged PR, since `main` requires review).
- Runs on a new self-hosted runner (`fmis-prod-runner`, label `fmis-prod`) installed directly on the production host as a user-level systemd service (`~/.config/systemd/user/actions-runner-fmis.service`), registered to this repo only.
- Steps: fast-forward the live checkout at `/home/buddhika/NetBeansProjects/dev/fmis` to `origin/main` → `mvn package` in that same directory (rebuilds `target/fmis-0.1` in place, which is exactly the directory Payara directory-deploys `/fmis` from) → `asadmin deploy --force=true` to reload it.
- Deliberately does **not** use `actions/checkout` — it builds in the existing production checkout rather than a separate workspace, so there's no "build elsewhere then copy" step.
- If the fast-forward or build step fails, the job stops before redeploying: the previously-built `target/fmis-0.1` is left untouched (Maven doesn't touch it until packaging succeeds), and the failure is visible in the Actions run log.

## Test plan
- [ ] Merge this PR and confirm the `Deploy to production` workflow run appears under Actions and completes successfully on the `fmis-prod-runner`
- [ ] Confirm `asadmin list-applications` still shows `fmis` deployed and `http://localhost:8080/fmis` serves correctly afterward
- [ ] Push an intentionally broken change to a throwaway branch/PR to confirm a failed build does *not* trigger a redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)