### PR TITLE
Fix CPC report date filter and add Excel export to fuel station summary

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/ReportController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/ReportController.java
@@ -722,7 +722,8 @@ public class ReportController implements Serializable {
                     null,
                     null,
                     null,
-                    null);
+                    null,
+                    true);
         } else {
             transactionLights = fillFuelTransactions(null,
                     toInstitution,
@@ -731,7 +732,8 @@ public class ReportController implements Serializable {
                     null,
                     null,
                     null,
-                    null);
+                    null,
+                    true);
         }
 
     }
@@ -739,6 +741,15 @@ public class ReportController implements Serializable {
     public List<FuelTransactionLight> fillFuelTransactions(
             Institution requestingInstitution, Institution fuelStation, Date fd, Date td,
             VehicleType vehicleType, VehiclePurpose vehiclePurpose, Driver driver, InstitutionType institutionType) {
+        return fillFuelTransactions(requestingInstitution, fuelStation, fd, td,
+                vehicleType, vehiclePurpose, driver, institutionType, false);
+    }
+
+    public List<FuelTransactionLight> fillFuelTransactions(
+            Institution requestingInstitution, Institution fuelStation, Date fd, Date td,
+            VehicleType vehicleType, VehiclePurpose vehiclePurpose, Driver driver, InstitutionType institutionType,
+            boolean filterByIssuedDate) {
+        String dateColumn = filterByIssuedDate ? "ft.issuedDate" : "ft.requestedDate";
 
         StringBuilder jpqlBuilder = new StringBuilder();
         jpqlBuilder.append("SELECT new lk.gov.health.phsp.pojcs.FuelTransactionLight(")
@@ -786,7 +797,7 @@ public class ReportController implements Serializable {
             tdCal.set(Calendar.MILLISECOND, 999);
             td = tdCal.getTime(); // End of the toDate
 
-            jpqlBuilder.append("AND ft.requestedDate BETWEEN :fromDate AND :toDate ");
+            jpqlBuilder.append("AND ").append(dateColumn).append(" BETWEEN :fromDate AND :toDate ");
             parameters.put("fromDate", fd);
             parameters.put("toDate", td);
         }
@@ -807,7 +818,7 @@ public class ReportController implements Serializable {
             parameters.put("instType", institutionType);
         }
 
-        jpqlBuilder.append("ORDER BY ft.requestedDate");
+        jpqlBuilder.append("ORDER BY ").append(dateColumn);
 
         List<FuelTransactionLight> resultList = (List<FuelTransactionLight>) fuelTransactionFacade.findLightsByJpql(
                 jpqlBuilder.toString(), parameters, TemporalType.DATE);
@@ -953,6 +964,15 @@ public class ReportController implements Serializable {
             List<Institution> requestingInstitutions, List<Institution> fuelStations,
             Date fd, Date td, VehicleType vehicleType, VehiclePurpose vehiclePurpose,
             Driver driver, InstitutionType institutionType) {
+        return fillFuelTransactions(requestingInstitutions, fuelStations, fd, td,
+                vehicleType, vehiclePurpose, driver, institutionType, false);
+    }
+
+    public List<FuelTransactionLight> fillFuelTransactions(
+            List<Institution> requestingInstitutions, List<Institution> fuelStations,
+            Date fd, Date td, VehicleType vehicleType, VehiclePurpose vehiclePurpose,
+            Driver driver, InstitutionType institutionType, boolean filterByIssuedDate) {
+        String dateColumn = filterByIssuedDate ? "ft.issuedDate" : "ft.requestedDate";
 
         StringBuilder jpqlBuilder = new StringBuilder();
 
@@ -987,7 +1007,7 @@ public class ReportController implements Serializable {
         }
 
         if (fd != null && td != null) {
-            jpqlBuilder.append("AND ft.requestedDate BETWEEN :fromDate AND :toDate ");
+            jpqlBuilder.append("AND ").append(dateColumn).append(" BETWEEN :fromDate AND :toDate ");
             parameters.put("fromDate", fd);
             parameters.put("toDate", td);
         }
@@ -1012,7 +1032,7 @@ public class ReportController implements Serializable {
             parameters.put("instType", institutionType);
         }
 
-        jpqlBuilder.append("ORDER BY ft.requestedDate");
+        jpqlBuilder.append("ORDER BY ").append(dateColumn);
 
         List<FuelTransactionLight> resultList = (List<FuelTransactionLight>) fuelTransactionFacade.findLightsByJpql(
                 jpqlBuilder.toString(), parameters, TemporalType.DATE);

--- a/src/main/webapp/reports/cpc/fuel_station_summary.xhtml
+++ b/src/main/webapp/reports/cpc/fuel_station_summary.xhtml
@@ -25,10 +25,17 @@
                                          ajax="false"
                                          action="#{reportController.fillDieselDistributionFuelStationSummaryForCPCRegionalOffice()}" />
 
+                        <p:commandButton value="Download Excel"
+                                         ajax="false"
+                                         icon="pi pi-file-excel">
+                            <p:dataExporter type="xlsx" target="tbl" fileName="Fuel Station Summary" />
+                        </p:commandButton>
+
                     </p:panelGrid>
 
                     <!-- Data Table -->
-                    <p:dataTable var="summary"
+                    <p:dataTable id="tbl"
+                                 var="summary"
                                  value="#{reportController.issuedSummaries}"
                                  paginator="true"
                                  rows="10"
@@ -52,7 +59,7 @@
                             </h:outputText>
                         </p:column>
 
-                        <p:column headerText="Action">
+                        <p:column headerText="Action" exportable="false">
                             <p:commandButton value="View Details" action="#{reportController.navigateToComprehensiveSummaryFromFuelStationSummaryForCpcRegionalOffice()}" ajax="false">
                                 <f:setPropertyActionListener value="#{summary.fuelStation}" target="#{reportController.toInstitution}" />
                             </p:commandButton>


### PR DESCRIPTION
## Summary
- **reports/cpc/list.xhtml date filter**: the From/To range was filtering FuelTransaction.requestedDate — the same field used by the requesting institution's own view — instead of issuedDate. For a fuel station reviewing what it has dispensed, filtering by issued date is correct. ReportController.fillFuelTransactions(...) gains a filterByIssuedDate boolean (applied to both WHERE and ORDER BY); existing 8-arg call sites are preserved via delegating overloads passing false, so every other caller (reports/list.xhtml, reports/list_institution.xhtml, reports/cpc_head_office/list.xhtml) is unaffected. Only fillFuelTransactionsForCpc() now passes true.
- **reports/cpc/fuel_station_summary.xhtml Excel export**: added a "Download Excel" button next to Process, exporting the data table via p:dataExporter. The "Action" column (View Details button) is marked exportable="false" so the exported file only contains the summary data, not a button column.

## Test plan
- [ ] On reports/cpc/list.xhtml, set a From/To range and confirm results match transactions issued in that range (not just requested in that range)
- [ ] Confirm reports/list.xhtml, reports/list_institution.xhtml, and reports/cpc_head_office/list.xhtml still filter/sort by requested date (unchanged)
- [ ] On reports/cpc/fuel_station_summary.xhtml, click "Download Excel" and confirm the file has Fuel Station / Fuel Station Code / Sum of Issued Qty columns only (no Action/button column)
- [ ] mvn package builds clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)