### PR TITLE
Warn when Issued Date differs from Requested Date by more than 3 days

### DIFF
--- a/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
+++ b/src/main/java/lk/gov/health/phsp/bean/FuelRequestAndIssueController.java
@@ -4,6 +4,7 @@ import lk.gov.health.phsp.entity.FuelTransaction;
 import lk.gov.health.phsp.facade.FuelTransactionHistoryFacade;
 
 import java.io.Serializable;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -87,6 +88,8 @@ public class FuelRequestAndIssueController implements Serializable {
     private FuelTransaction selected;
     private String odoWarningMessage;
     private boolean odoWarningAcknowledged;
+    private String issuedDateWarningMessage;
+    private boolean issuedDateWarningAcknowledged;
 
     private FuelTransactionHistory selectedTransactionHistory;
     private List<FuelTransactionHistory> selectedTransactionHistories;
@@ -268,6 +271,8 @@ public class FuelRequestAndIssueController implements Serializable {
     }
 
     public String navigateToMarkVehicleFuelRequest() {
+        issuedDateWarningMessage = null;
+        issuedDateWarningAcknowledged = false;
         if (selected == null) {
             JsfUtil.addErrorMessage("Nothing selected");
             return "";
@@ -540,6 +545,25 @@ public class FuelRequestAndIssueController implements Serializable {
         return odoWarningMessage != null;
     }
 
+    public String acknowledgeIssuedDateWarningAndSubmitMark() {
+        issuedDateWarningAcknowledged = true;
+        return submitMarkVehicleFuelRequestIssue();
+    }
+
+    public String cancelIssuedDateWarning() {
+        issuedDateWarningMessage = null;
+        issuedDateWarningAcknowledged = false;
+        return "";
+    }
+
+    public String getIssuedDateWarningMessage() {
+        return issuedDateWarningMessage;
+    }
+
+    public boolean isIssuedDateWarningPending() {
+        return issuedDateWarningMessage != null;
+    }
+
     // ===== Fuel order validation helpers =====
 
     private boolean isReferenceNumberUnique(String referenceNumber, Institution institution, Date referenceDate) {
@@ -604,6 +628,11 @@ public class FuelRequestAndIssueController implements Serializable {
         c2.setTime(d2);
         return c1.get(Calendar.YEAR) == c2.get(Calendar.YEAR)
                 && c1.get(Calendar.MONTH) == c2.get(Calendar.MONTH);
+    }
+
+    private long getDifferenceInDays(Date d1, Date d2) {
+        long diffMillis = Math.abs(d2.getTime() - d1.getTime());
+        return diffMillis / (1000 * 60 * 60 * 24);
     }
 
     private boolean areFieldValuesDistinct(String referenceNumber, Double odoReading, Double requestQuantity) {
@@ -758,6 +787,22 @@ public class FuelRequestAndIssueController implements Serializable {
             JsfUtil.addErrorMessage("Issued Date cannot be before the Requested Date");
             return "";
         }
+
+        // Validation: Issued Date should not be far from the Requested Date.
+        // Not blocked outright - the user is warned and can confirm to proceed anyway.
+        if (selected.getRequestedDate() != null && !issuedDateWarningAcknowledged) {
+            long daysDiff = getDifferenceInDays(selected.getIssuedDate(), selected.getRequestedDate());
+            if (daysDiff > 3) {
+                SimpleDateFormat sdf = new SimpleDateFormat("dd MMMM yyyy");
+                issuedDateWarningMessage = "The Issued Date and Requested Date differ by " + daysDiff
+                        + " days. Requested At: " + sdf.format(selected.getRequestedDate())
+                        + " — Issued Date: " + sdf.format(selected.getIssuedDate())
+                        + ". Do you want to continue anyway?";
+                return "";
+            }
+        }
+        issuedDateWarningAcknowledged = false;
+
         if (selected.getIssueReferenceNumber() != null && selected.getRequestReferenceNumber() != null
                 && selected.getIssueReferenceNumber().trim().equalsIgnoreCase(selected.getRequestReferenceNumber().trim())) {
             JsfUtil.addErrorMessage("Issue Reference Number (Invoice Number) cannot be the same as the Request Reference Number. They are two separate numbers.");

--- a/src/main/webapp/requests/mark.xhtml
+++ b/src/main/webapp/requests/mark.xhtml
@@ -272,6 +272,50 @@
                                 </div>
                             </div>
 
+                            <!-- Issued Date warning dialog: shown instead of blocking submission outright -->
+                            <p:dialog header="Issued Date Warning"
+                                      widgetVar="issuedDateWarningDialog"
+                                      modal="true"
+                                      closable="false"
+                                      responsive="true"
+                                      visible="#{fuelRequestAndIssueController.issuedDateWarningPending}">
+                                <div class="p-3">
+                                    <p class="text-danger">
+                                        <i class="pi pi-exclamation-triangle" />
+                                        <h:outputText value=" #{fuelRequestAndIssueController.issuedDateWarningMessage}" />
+                                    </p>
+                                    <table class="table mt-2">
+                                        <tr>
+                                            <td><b>Requested At:</b></td>
+                                            <td>
+                                                <h:outputText value="#{fuelRequestAndIssueController.selected.requestedDate}">
+                                                    <f:convertDateTime pattern="dd MMMM yyyy"></f:convertDateTime>
+                                                </h:outputText>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td><b>Issued Date:</b></td>
+                                            <td>
+                                                <h:outputText value="#{fuelRequestAndIssueController.selected.issuedDate}">
+                                                    <f:convertDateTime pattern="dd MMMM yyyy"></f:convertDateTime>
+                                                </h:outputText>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </div>
+                                <div class="text-center mt-3 mb-3">
+                                    <p:commandButton value="Mark as Issued Anyway"
+                                                     icon="pi pi-check"
+                                                     styleClass="ui-button-raised ui-button-warning mx-1"
+                                                     action="#{fuelRequestAndIssueController.acknowledgeIssuedDateWarningAndSubmitMark}"
+                                                     ajax="false" />
+                                    <p:commandButton value="Go Back and Edit"
+                                                     icon="pi pi-times"
+                                                     styleClass="ui-button-raised ui-button-secondary mx-1"
+                                                     action="#{fuelRequestAndIssueController.cancelIssuedDateWarning}"
+                                                     ajax="false" />
+                                </div>
+                            </p:dialog>
 
                         </div>
                     </h:form>


### PR DESCRIPTION
## Summary
- On `requests/mark.xhtml`, "Mark as Issued" only hard-blocked when the Issued Date was *before* the Requested Date — a typo'd issued date (wrong month/year) far off from the requested date would silently go through.
- Adds a non-blocking warning dialog (mirroring the existing ODO-meter-reading warning pattern) when Issued Date and Requested Date differ by more than 3 days, showing both dates so the user can confirm intentional delayed issuance or go back and correct the date.

## Test plan
- [ ] `mvn compile` succeeds
- [ ] Open a pending request in `requests/mark.xhtml` with Requested Date >3 days in the past
- [ ] Enter an Issued Date >3 days apart, submit "Mark as Issued" — warning dialog appears showing both dates
- [ ] "Go Back and Edit" closes dialog without saving; correcting the date and resubmitting within 3 days succeeds normally
- [ ] "Mark as Issued Anyway" saves the request as issued and navigates away as before
- [ ] Existing hard-block (issued date before requested date) still fires unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)